### PR TITLE
Fix a few syntax errors in templates

### DIFF
--- a/Project_0.Altis/Templates/Factions/RHS_AAF2017_elite.sqf
+++ b/Project_0.Altis/Templates/Factions/RHS_AAF2017_elite.sqf
@@ -81,7 +81,7 @@ _veh set [T_VEH_stat_mortar_light, ["RHS_M252_D"]];
 _veh set [T_VEH_stat_mortar_heavy, ["RHS_M119_D"]];
 
 //TODO remove HIDF markings from UH1 via garage, move UH1 to reserve
-_veh set [T_VEH_heli_light, ["FGN_AAF_KA60_unarmed","rhs_uh1h_hidf", "RHS_MELB_H6M", "RHS_MELB_MH6M",]];
+_veh set [T_VEH_heli_light, ["FGN_AAF_KA60_unarmed","rhs_uh1h_hidf", "RHS_MELB_H6M", "RHS_MELB_MH6M"]];
 _veh set [T_VEH_heli_heavy, ["FGN_AAF_KA60_dynamicLoadout","rhs_uh1h_hidf_gunship", "RHS_MELB_AH6M"]];
 _veh set [T_VEH_heli_cargo, ["FGN_AAF_KA60_unarmed","rhs_uh1h_hidf_unarmed"]];
 _veh set [T_VEH_heli_attack, ["rhsgref_mi24g_CAS"]]; //TODO add dynamic loadout variants for more variety

--- a/Project_0.Altis/Templates/Factions/RHS_AFRF.sqf
+++ b/Project_0.Altis/Templates/Factions/RHS_AFRF.sqf
@@ -41,7 +41,7 @@ _inf set [T_INF_recon_rifleman, ["rhs_vmf_recon_rifleman", "rhs_vmf_recon_riflem
 _inf set [T_INF_recon_medic, ["rhs_vmf_recon_medic"]];
 _inf set [T_INF_recon_exp, ["rhs_vmf_recon_grenadier", "rhs_vmf_recon_grenadier_scout"]];
 _inf set [T_INF_recon_LAT, ["rhs_vmf_recon_rifleman_lat"]];
-_inf set [T_INF_recon_LMG, ["rhs_vmf_recon_arifleman", "rhs_vmf_recon_arifleman_scout"]];
+//_inf set [T_INF_recon_LMG, ["rhs_vmf_recon_arifleman", "rhs_vmf_recon_arifleman_scout"]]; // There is no T_INF_recon_LMG right now
 _inf set [T_INF_recon_marksman, ["rhs_vmf_recon_marksman", "rhs_vmf_recon_marksman_vss"]];
 _inf set [T_INF_recon_JTAC, ["rhs_vmf_recon_rifleman_scout", "rhs_vmf_recon_rifleman_scout_akm"]];
 
@@ -59,11 +59,11 @@ _veh set [T_VEH_SIZE-1, nil];
 _veh set [T_VEH_DEFAULT, ["rhs_uaz_MSV_01"]];
 
 _veh set [T_VEH_car_unarmed, ["rhs_uaz_open_MSV_01", "RHS_UAZ_MSV_01"]];
-_veh set [T_VEH_car_armed, ["rhsgref_nat_uaz_spg9", "rhsgref_nat_uaz_dshkm" "rhsgref_nat_uaz_ags"]];
+_veh set [T_VEH_car_armed, ["rhsgref_nat_uaz_spg9", "rhsgref_nat_uaz_dshkm", "rhsgref_nat_uaz_ags"]];
 
 _veh set [T_VEH_MRAP_unarmed, ["rhs_tigr_msv", "rhs_tigr_m_msv", "rhsgref_BRDM2UM_msv"]];
 _veh set [T_VEH_MRAP_HMG, ["rhs_tigr_sts_msv", "rhsgref_BRDM2_msv", "rhsgref_BRDM2_HQ_msv"]];
-_veh set [T_VEH_MRAP_GMG, ["rhs_tigr_sts_msv" "rhsgref_BRDM2_ATGM_msv"]];
+_veh set [T_VEH_MRAP_GMG, ["rhs_tigr_sts_msv", "rhsgref_BRDM2_ATGM_msv"]];
 
 _veh set [T_VEH_IFV, ["rhs_bmp2_tv", "rhs_bmp2k_tv", "rhs_bmp3_msv", "rhs_bmp3_late_msv"]];
 _veh set [T_VEH_APC, ["rhs_btr80_msv", "rhs_btr80a_msv"]];

--- a/Project_0.Altis/Templates/Factions/RHS_USAF.sqf
+++ b/Project_0.Altis/Templates/Factions/RHS_USAF.sqf
@@ -42,7 +42,7 @@ _inf set [T_INF_recon_medic, ["rhsusf_socom_marsoc_sarc"]];
 _inf set [T_INF_recon_exp, ["rhsusf_socom_marsoc_cso_breacher","rhsusf_socom_marsoc_cso_eod", "rhsusf_socom_marsoc_cso_mechanic"]];
 //_inf set [T_INF_recon_LAT, [""]];
 _inf set [T_INF_recon_marksman, ["rhsusf_socom_marsoc_sniper", "rhsusf_socom_marsoc_sniper_m107", "rhsusf_socom_marsoc_marksman"]];
-_inf set [T_INF_recon_spotter, ["rhsusf_socom_marsoc_cso_mk17_light", "rhsusf_socom_marsoc_cso_light", "rhsusf_socom_marsoc_spotter"]];
+//_inf set [T_INF_recon_spotter, ["rhsusf_socom_marsoc_cso_mk17_light", "rhsusf_socom_marsoc_cso_light", "rhsusf_socom_marsoc_spotter"]]; // There is no T_INF_recon_spotter
 _inf set [T_INF_recon_JTAC, ["rhsusf_socom_marsoc_jtac", "rhsusf_socom_marsoc_jfo"]];
 
 


### PR DESCRIPTION
Two missing commas and two non-existing subcategory names