### PR TITLE
undid my previous button fuckup in CMUI, changed to new logo color

### DIFF
--- a/Vindicta.Altis/UI/ClientMapUI/ClientMapUI.sqf
+++ b/Vindicta.Altis/UI/ClientMapUI/ClientMapUI.sqf
@@ -159,7 +159,7 @@ CLASS(CLASS_NAME, "")
 		 ! ! ! ! !  ! ! ! ! ! ! ! ! ! */
 		pr _ctrl = ([_mapDisplay, "CMUI_INTEL_INACTIVE"] call ui_fnc_findCheckboxButton);
 		_ctrl ctrlAddEventHandler ["ButtonDown", { CALLM(gClientMapUI, "onButtonClickShowIntelInactive", _this); }];
-		[_ctrl, false, false] call ui_fnc_buttonCheckboxSetState;
+		[_ctrl, true, false] call ui_fnc_buttonCheckboxSetState;
 
 		pr _ctrl = ([_mapDisplay, "CMUI_INTEL_ACTIVE"] call ui_fnc_findCheckboxButton);
 		_ctrl ctrlAddEventHandler ["ButtonDown", { CALLM(gClientMapUI, "onButtonClickShowIntelActive", _this); }];
@@ -167,7 +167,7 @@ CLASS(CLASS_NAME, "")
 
 		pr _ctrl = ([_mapDisplay, "CMUI_INTEL_ENDED"] call ui_fnc_findCheckboxButton);
 		_ctrl ctrlAddEventHandler ["ButtonDown", { CALLM(gClientMapUI, "onButtonClickShowIntelEnded", _this); }];
-		[_ctrl, false, false] call ui_fnc_buttonCheckboxSetState;
+		[_ctrl, true, false] call ui_fnc_buttonCheckboxSetState;
 
 		pr _ctrl = ([_mapDisplay, "CMUI_BUTTON_LOC"] call ui_fnc_findCheckboxButton);
 		_ctrl ctrlAddEventHandler ["ButtonDown", { CALLM(gClientMapUI, "onButtonClickShowLocations", _this); }];

--- a/Vindicta.Altis/UI/Resources/UIProfileColors.h
+++ b/Vindicta.Altis/UI/Resources/UIProfileColors.h
@@ -32,7 +32,7 @@ Macros for user-defined GUI colors
 #define MUIC_WHITE {1, 1, 1, 1}
 #define MUIC_TXT_DISABLED {0.3, 0.3, 0.3, 1}
 #define MUIC_MISSION {1, 0.682, 0, 1}
-#define MUIC_LOGO {0.7, 0, 0, 1}
+#define MUIC_LOGO {0.663, 0.153, 0.149, 1}
 
 // Base colors for SQF
 #define MUIC_COLOR_TRANSPARENT [0, 0, 0, 0]


### PR DESCRIPTION
- Fixed previous fuckup in CMUI. In which I only changed the appearance of the Intel Ended and Intel Inactive buttons. I may properly toggle them off by default at some point.

- New logo color (Sparker's choice).