### PR TITLE
Arrest fixes

### DIFF
--- a/Vindicta.Altis/AI/Unit/ActionUnitArrest.sqf
+++ b/Vindicta.Altis/AI/Unit/ActionUnitArrest.sqf
@@ -180,7 +180,11 @@ CLASS("ActionUnitArrest", "Action")
 				};
 			}; // end CATCH UP
 
-			// SEARCH AND ARREST
+			/*
+				MOVE TO AND ARREST
+
+				AI unit is now close and closing the gap to perform the actual arrest.
+			*/
 			case 1: {
 				OOP_INFO_0("ActionUnitArrest: Searching/Arresting target.");
 
@@ -223,25 +227,6 @@ CLASS("ActionUnitArrest", "Action")
 								// only perform arrest if unit IS actually close enough, prevent magic hands
 								if (getPos _captor distance getPos _target < MIN_ARREST_DIST) then {
 									CALLSM1("ActionUnitArrest", "performArrest", _target);
-								} else {
-									// player is presumed to have gone on the run! Set overt and kill!
-									pr _sentence = selectRandom [
-									"NEVER SHOULD HAVE COME HERE!",
-									"YOU ASKED FOR IT!",
-									"HE'S GOT A GUN!",
-									"DO NOT MOVE!",
-									"HOSTILE!",
-									"SHOTS FIRED!",
-									"OPEN FIRE!"
-									]; 
-
-									[_captor, _sentence, _target] call Dialog_fnc_hud_createSentence;
-
-									pr _args = [_target, 3.0];
-									REMOTE_EXEC_CALL_STATIC_METHOD("undercoverMonitor", "boostSuspicion", _args, _target, false);
-									_captor setBehaviour "COMBAT";
-									_captor doWatch _target;
-									
 								};
 							};
 
@@ -267,11 +252,15 @@ CLASS("ActionUnitArrest", "Action")
 
 					breakTo "switch";
 				};
-			}; // end SEARCH AND ARREST
+			}; // end MOVE TO AND ARREST
 
 			// FAILED
 			case 2: {
-				OOP_INFO_0("ActionUnitArrest: FAILED CATCH UP.");
+				OOP_INFO_0("ActionUnitArrest: FAILED CATCH UP. Player will be made overt.");
+
+				if (isPlayer _target) then {
+					CALLSM2("ActionUnitArrest", "killArrestTarget", _target, _captor);	
+				};
 
 				_state = ACTION_STATE_FAILED;
 			};
@@ -289,7 +278,10 @@ CLASS("ActionUnitArrest", "Action")
 		_state
 	} ENDMETHOD;
 
-	// Performs the actual arrest of target
+	/*
+		Performs the actual arrest of targeted civilian or player.
+		
+	*/
 	STATIC_METHOD("performArrest") {
 		params [P_THISCLASS, P_OBJECT("_target")];
 
@@ -310,9 +302,34 @@ CLASS("ActionUnitArrest", "Action")
 			};
 		
 			_target setVariable ["timeArrested", time+10];
-
 			REMOTE_EXEC_CALL_STATIC_METHOD("UndercoverMonitor", "onUnitArrested", [_target], _target, false);
 		};
+	} ENDMETHOD;
+
+	/*
+		Called only for PLAYER. Player is presumed to have purposely evaded arrest.
+		Makes player (target) go overt in Undercover. Makes unit doing the arrest (captor) go into combat.
+	*/
+	STATIC_METHOD("killArrestTarget") {
+		params [P_THISCLASS, P_OBJECT("_target"), P_OBJECT("_captor")];
+
+		pr _sentence = selectRandom [
+			"NEVER SHOULD HAVE COME HERE!",
+			"YOU ASKED FOR IT!",
+			"HE'S GOT A GUN!",
+			"DO NOT MOVE!",
+			"HOSTILE!",
+			"SHOTS FIRED!",
+			"OPEN FIRE!"
+		]; 
+
+		[_captor, _sentence, _target] call Dialog_fnc_hud_createSentence;
+
+		pr _args = [_target, 3.0];
+		REMOTE_EXEC_CALL_STATIC_METHOD("undercoverMonitor", "boostSuspicion", _args, _target, false);
+
+		_captor setBehaviour "COMBAT";
+		_captor doWatch _target;
 	} ENDMETHOD;
 	
 	// logic to run when the action is satisfied

--- a/Vindicta.Altis/Templates/Loadouts/ArsenalLoadout.sqf
+++ b/Vindicta.Altis/Templates/Loadouts/ArsenalLoadout.sqf
@@ -1,18 +1,15 @@
 /*
 ----------------------------------------------------------------------------------------------
-							LIST OF "CIVILIAN" GEAR AND VEHICLES
+    ARRAYS OF DEFAULT INFINITE ARSENAL EQUIPMENT 
 ----------------------------------------------------------------------------------------------
 */
 
-
-
-/* 
-----------------------------------------------------------------------------------------------
-	CIVILIAN CLOTHING
-----------------------------------------------------------------------------------------------
-*/
-
-g_UM_civUniforms = [
+g_ArsenalLoadout_Uniforms = [
+	"U_BG_Guerilla2_1",
+    "U_BG_Guerilla2_2",
+    "U_BG_Guerilla2_3",
+    "U_BG_Guerilla3_1",
+    "U_BG_Guerilla3_2",
     "U_C_Commoner_shorts",
     "U_C_ConstructionCoverall_Black_F",
     "U_C_ConstructionCoverall_Blue_F",
@@ -65,10 +62,28 @@ g_UM_civUniforms = [
     "U_I_C_Soldier_Bandit_3_F",
     "U_I_C_Soldier_Bandit_4_F",
     "U_I_C_Soldier_Bandit_5_F",
+    "U_IG_Guerilla2_1",
+    "U_IG_Guerilla2_2",
+    "U_IG_Guerilla2_3",
+    "U_IG_Guerilla3_1",
+    "U_IG_Guerilla3_2",
+    "U_BG_Guerrilla_6_1",
+    "U_I_C_Soldier_Para_4_F",
+    "U_I_L_Uniform_01_camo_F",
+    "U_I_L_Uniform_01_deserter_F",
+    "U_I_G_resistanceLeader_F",
+    "U_BG_Guerilla1_1",
+    "U_I_C_Soldier_Para_3_F",
     "U_Marshal",
+    "U_OG_Guerilla2_1",
+    "U_OG_Guerilla2_2",
+    "U_OG_Guerilla2_3",
+    "U_OG_Guerilla3_1",
+    "U_OG_Guerilla3_2",
     "U_C_HunterBody_grn",
     "U_OrestesBody",
     "U_Rangemaster",
+    "U_BG_leader",
 
     // CONTACT DLC 
     "U_I_L_Uniform_01_tshirt_black_F",
@@ -84,7 +99,10 @@ g_UM_civUniforms = [
 ];
 
 
-g_UM_civHeadgear = [
+g_ArsenalLoadout_Headgear = [
+    "H_Shemag_olive",
+    "H_ShemagOpen_tan",
+    "H_ShemagOpen_khk",
     "H_Hat_Tinfoil_F",
     "H_Bandanna_blu",
     "H_Bandanna_camo",
@@ -174,14 +192,8 @@ g_UM_civHeadgear = [
     "H_StrawHat_dark"
 ];
 
-g_UM_civVests = [
-    "V_DeckCrew_blue_F",
-    "V_DeckCrew_brown_F",
-    "V_DeckCrew_green_F",
-    "V_DeckCrew_red_F",
-    "V_DeckCrew_violet_F",
-    "V_DeckCrew_white_F",
-    "V_DeckCrew_yellow_F",
+/*
+g_ArsenalLoadout_Vests = [
     "V_Plain_crystal_F",
     "V_Plain_medical_F",
     "V_Pocketed_black_F",
@@ -191,9 +203,19 @@ g_UM_civVests = [
     "V_Safety_orange_F",
     "V_Safety_yellow_F"
 ];
+*/
 
-g_UM_civFacewear = [
-    "G_Aviator",
+g_ArsenalLoadout_Facewear = [
+    //"G_Aviator",
+    "G_Balaclava_blk",
+    "G_Balaclava_oli",
+    "G_Bandanna_beast",
+    "G_Bandanna_blk",
+    "G_Bandanna_khk",
+    "G_Bandanna_oli",
+    "G_Bandanna_tan",
+    "G_AirPurifyingRespirator_01_F",
+    "G_RegulatorMask_F",
     "G_Combat",
     "G_Combat_Goggles_tna_F",
     "G_EyeProtectors_Earpiece_F",
@@ -224,112 +246,9 @@ g_UM_civFacewear = [
     "G_Tactical_Clear"
 ];
 
-g_UM_civBackpacks = [
+g_ArsenalLoadout_Backpacks = [
     "ACE_TacticalLadder_Pack",
 	"B_Messenger_Black_F",
     "B_Messenger_Coyote_F",
     "B_Messenger_Olive_F"
 ];
-
-g_UM_ghillies = [
-	"U_B_FullGhillie_ard",
-    "U_B_FullGhillie_lsh",
-    "U_B_FullGhillie_sard",
-    "U_B_GhillieSuit",
-    "U_B_T_FullGhillie_tna_F",
-    "U_I_FullGhillie_ard",
-    "U_I_FullGhillie_lsh",
-    "U_I_FullGhillie_sard",
-    "U_I_GhillieSuit",
-    "U_O_FullGhillie_ard",
-    "U_O_FullGhillie_lsh",
-    "U_O_FullGhillie_sard",
-    "U_O_GhillieSuit",
-    "U_O_T_FullGhillie_tna_F"
-];
-
-/* 
-----------------------------------------------------------------------------------------------
-	ITEMS
-----------------------------------------------------------------------------------------------
-*/
-
-g_UM_civItems = [
-	"ItemWatch",
-	"Toolkit",
-	"Medikit",
-	"FirstAidKit"
-];
-
-// Exceptions for certain "dummy weapons" used in some innocent animations
-g_UM_civWeapons = [
-    "ACE_FakePrimaryWeapon",
-    "Rifle_Base_F",
-    "CarHorn",
-    "TruckHorn",
-    "Binocular",
-    "Rangefinder",
-    "Laserdesignator",
-    "Laserdesignator_02",
-    "Laserdesignator_03",
-    ""
-];
-
-g_UM_suspWeapons = [
-    "Binocular",
-    "Rangefinder",
-    "Laserdesignator",
-    "Laserdesignator_02",
-    "Laserdesignator_03"
-]; 
-
-/* 
-----------------------------------------------------------------------------------------------
-	VEHICLES
-----------------------------------------------------------------------------------------------
-*/
-
-// no longer used array of civilian vehicles 
-/*
-g_civVehs = [
-    "C_Hatchback_01_sport_F",
-    "C_Hatchback_01_F",
-    "C_Truck_02_box_F",
-    "C_Truck_02_fuel_F",
-    "C_Offroad_02_unarmed_F",
-    "C_Van_01_fuel_F",
-    "C_Truck_02_transport_F",
-    "C_Truck_02_covered_F",
-    "C_Kart_01_F",
-    "C_Kart_01_Blu_F",
-    "C_Kart_01_Fuel_F",
-    "C_Kart_01_Red_F",
-    "C_Kart_01_Vrana_F",
-    "C_Offroad_01_F",
-    "C_Offroad_01_repair_F",
-    "C_Quadbike_01_F",
-    "C_SUV_01_F",
-    "C_Van_01_transport_F",
-    "C_Van_02_medevac_F",
-    "C_Van_02_vehicle_F",
-    "C_Van_02_service_F",
-    "C_Van_02_transport_F",
-    "C_IDAP_Offroad_02_unarmed_F",
-    "C_IDAP_Offroad_01_F",
-    "C_IDAP_Van_02_medevac_F",
-    "C_IDAP_Van_02_vehicle_F",
-    "C_IDAP_Van_02_transport_F",
-    "C_IDAP_Truck_02_transport_F",
-    "C_IDAP_Truck_02_F",
-    "C_IDAP_Truck_02_water_F",
-    "C_Boat_Civil_01_F",
-    "C_Boat_Civil_01_rescue_F",
-    "C_Rubberboat",
-    "C_Boat_Transport_02_F",
-    "C_Scooter_Transport_01_F",
-    "I_C_Van_02_transport_F",
-    "I_C_Van_02_vehicle_F"
-];
-
-*/
-

--- a/Vindicta.Altis/Undercover/fn_UM_addActionUntieLocal.sqf
+++ b/Vindicta.Altis/Undercover/fn_UM_addActionUntieLocal.sqf
@@ -27,8 +27,12 @@ params [["_unit", objNull, [objNull]]];
 	"_this distance _target < 3",
 	"_caller distance _target < 3",
 	{},
-	{},
-	{ 	
+	{ // code during progress
+		params ["_target", "_caller", "_actionId", "_arguments", "_progress", "_maxProgress"];
+		private _args = [_target, 3.0];
+		REMOTE_EXEC_CALL_STATIC_METHOD("undercoverMonitor", "boostSuspicion", _args, _target, false);
+	},
+	{ // code when finished
 		params ["_target", "_caller", "_actionId", "_arguments", "_progress", "_maxProgress"];
 		REMOTE_EXEC_CALL_STATIC_METHOD("UndercoverMonitor", "setUnitFree", [_target], _target, false);	
 	},

--- a/Vindicta.Altis/Undercover/fn_UM_addActionUntieMP.sqf
+++ b/Vindicta.Altis/Undercover/fn_UM_addActionUntieMP.sqf
@@ -26,8 +26,12 @@ params [["_unit", objNull, [objNull]]];
  	"_this distance _target < 3 && _this != _target", 
 	"_caller distance _target < 3",
 	{},
-	{},
-	{ 	
+	{ // code during progress
+		params ["_target", "_caller", "_actionId", "_arguments", "_progress", "_maxProgress"];
+		private _args = [_caller, 0.35];
+		REMOTE_EXEC_CALL_STATIC_METHOD("undercoverMonitor", "boostSuspicion", _args, _caller, false);
+	},
+	{ // code when finished	
 		params ["_target", "_caller", "_actionId", "_arguments", "_progress", "_maxProgress"];
 		REMOTE_EXEC_CALL_STATIC_METHOD("UndercoverMonitor", "setUnitFree", [_target], _target, false);	
 	},

--- a/Vindicta.Altis/Undercover/initClasses.sqf
+++ b/Vindicta.Altis/Undercover/initClasses.sqf
@@ -1,4 +1,5 @@
 call compile preprocessFileLineNumbers "Templates\Undercover\CivObjects.sqf";
+call compile preprocessFileLineNumbers "Templates\Loadouts\ArsenalLoadout.sqf";
 fnc_getVisibleSurface = compile preprocessfilelinenumbers "Undercover\fn_getVisibleSurface.sqf";
 fnc_UM_testCompromise = compile preprocessfilelinenumbers "Undercover\fn_UM_testCompromise.sqf";
 fnc_UM_setState = compile preprocessfilelinenumbers "Undercover\fn_UM_setState.sqf";

--- a/Vindicta.Altis/Undercover/undercoverMonitor.sqf
+++ b/Vindicta.Altis/Undercover/undercoverMonitor.sqf
@@ -593,9 +593,11 @@ CLASS("UndercoverMonitor", "MessageReceiver");
 							_unit setVariable ["timeArrested", time+10, true];
 						}; // do once when state changed
 
+						// glitched out of arrest animation
 						if (animationState _unit != "acts_aidlpsitmstpssurwnondnon01" && time > (_unit getVariable "timeArrested")) then {
 							T_SETV("bCaptive", false);
 							if (T_GETV("untieActionID") != -1) then { _unit removeAction T_GETV("untieActionID"); };
+							CALLSM2("undercoverMonitor", "boostSuspicion", _unit, 1.0);
 							OOP_INFO_0("Player appears to have glitched out of arrest animation.");
 						};
 

--- a/Vindicta.Altis/Undercover/undercoverMonitor.sqf
+++ b/Vindicta.Altis/Undercover/undercoverMonitor.sqf
@@ -351,7 +351,9 @@ CLASS("UndercoverMonitor", "MessageReceiver");
 								// Suspiciousness for being in a military area depends on the campaign progress
 								pr _progress = CALLM0(gGameModeServer, "getCampaignProgress"); // 0..1
 								pr _multiplier = 1+2*_progress;
-								_suspicionArr pushBack [_multiplier*SUSP_MIL_LOCATION, "In military area"];
+								if (_bInVeh) then { _suspicionArr pushBack [1, "In military area in a vehicle"]; } else {
+									_suspicionArr pushBack [_multiplier*SUSP_MIL_LOCATION, "In military area"];
+								};
 								_hintKeys pushBack HK_MILAREA;
 								OOP_INFO_0("In military area.");
 							};

--- a/Vindicta.Altis/Unit/Unit.sqf
+++ b/Vindicta.Altis/Unit/Unit.sqf
@@ -1986,7 +1986,7 @@ CLASS(UNIT_CLASS_NAME, "Storable")
 				pr _className = _x;
 				pr _index = [_className] call jn_fnc_arsenal_itemType;
 				(_arsenalArray#_index) pushBack [_className, -1];
-			} forEach (g_UM_civHeadgear + g_UM_civUniforms + g_UM_civFacewear + g_UM_civBackpacks);
+			} forEach (g_ArsenalLoadout_Headgear + g_ArsenalLoadout_Uniforms + g_ArsenalLoadout_Facewear + g_ArsenalLoadout_Backpacks);
 
 			_data set [UNIT_DATA_ID_LIMITED_ARSENAL, _arsenalArray]; // Limited Arsenal's empty array for items
 			if (isNull _hO) then {


### PR DESCRIPTION
I changed the arsenal default loadouts (global var arrays that are added to the arsenal when it's created). Is that gonna break saves?

Previously we added arrays meant for UndercoverMonitor to the arsenals. I made separate ones, because this meant every item in the arsenal would automatically be incognito. Now we can have overt uniforms etc.

+ removed aviator glasses from arsenal
+ added some non-undercover guerilla uniforms
+ added some non-undercover headgear and facewear
+ made some previously undercover guerilla uniforms non-undercover
+ various small changes to arrest, it's more aggressive and you will probably get shot (more changes needed)
+ can no longer drive into bases undercover regardless of campaign progresss