### PR TITLE
Add 3CB dependencies to 3CB Faction file

### DIFF
--- a/Vindicta.Altis/Templates/Factions/3CB_BAF.sqf
+++ b/Vindicta.Altis/Templates/Factions/3CB_BAF.sqf
@@ -16,8 +16,10 @@ _array set [T_REQUIRED_ADDONS, [
 	"uk3cb_baf_units_ace",	// BAF Ace Compat
 	"uk3cb_baf_units_rhs",	// BAF RHS Compat
 	"uk3cb_baf_vehicles_MAN", // BAF Vehicles
-	"uk3cb_baf_weapons_L110", // BAF Weaponry
-	"uk3cb_baf_weapons_ace" // BAF RHS Ammo Compat	
+	"uk3cb_baf_weapons_L110", // BAF Weapons
+	"uk3cb_baf_weapons_ace", // BAF RHS Ammo Compat
+	"uk3cb_baf_vehicles_chinook" // BAF Vehicles RHS Skins
+	"rksl_attachments_core" // RKSL Attachments
 ]];
 
 //==== Infantry ====

--- a/Vindicta.Altis/Templates/Factions/3CB_BAF.sqf
+++ b/Vindicta.Altis/Templates/Factions/3CB_BAF.sqf
@@ -18,7 +18,7 @@ _array set [T_REQUIRED_ADDONS, [
 	"uk3cb_baf_vehicles_MAN", // BAF Vehicles
 	"uk3cb_baf_weapons_L110", // BAF Weapons
 	"uk3cb_baf_weapons_ace", // BAF RHS Ammo Compat
-	"uk3cb_baf_vehicles_chinook" // BAF Vehicles RHS Skins
+	"uk3cb_baf_vehicles_chinook", // BAF Vehicles RHS Skins
 	"rksl_attachments_core" // RKSL Attachments
 ]];
 


### PR DESCRIPTION
Adds the sub-dependencies for 3CB and it's compat mods to the faction file

3CB Units (RHS compat) requires RHS vehicle rekins
3CB Weapons requires RKSL Attachments