### PR TITLE
AFRF Faction - Requiered Mods

### DIFF
--- a/Vindicta.Altis/Templates/Factions/RHS_AFRF.sqf
+++ b/Vindicta.Altis/Templates/Factions/RHS_AFRF.sqf
@@ -13,7 +13,8 @@ _array set [T_DISPLAY_NAME, "RHS AFRF"];
 _array set [T_FACTION, T_FACTION_Military];
 _array set [T_REQUIRED_ADDONS, [
 	"rhs_c_troops",		// RHSAFRF
-	"rhsusf_c_troops"	// RHSUSAF
+	"rhsusf_c_troops",	// RHSUSAF
+	"rhsgref_c_troops" //RHSGREF due to BRDMs, UAZ with DSHKMs not existing in base AFRF
 ]];
 
 //==== Infantry ====


### PR DESCRIPTION
Since the BRDMs and Armed UAZs used in the Template requiere RHSGref i added it.

I also assume there was the idea of doing that anyway since RHSUSAF was also requiered before.