### PR TITLE
Remove GREF vehicles from 2035:RAF faction, no longer dependant on RHS.

### DIFF
--- a/Vindicta.Altis/Templates/Factions/Russians2035.sqf
+++ b/Vindicta.Altis/Templates/Factions/Russians2035.sqf
@@ -64,7 +64,7 @@ _veh set [T_VEH_SIZE-1, nil];
 _veh set [T_VEH_DEFAULT, ["min_rf_gaz_2330"]];
 
 _veh set [T_VEH_car_unarmed, ["min_rf_gaz_2330"]];
-_veh set [T_VEH_car_armed, ["min_rf_gaz_2330_HMG", "rhsgref_nat_uaz_dshkm", "rhsgref_nat_uaz_ags"]];
+_veh set [T_VEH_car_armed, ["min_rf_gaz_2330_HMG"]];
 
 _veh set [T_VEH_MRAP_unarmed, ["min_rf_gaz_2330"]];
 _veh set [T_VEH_MRAP_HMG, ["min_rf_gaz_2330_HMG"]];


### PR DESCRIPTION
2035: RAF is a fairly light mod, but the faction file uses 2 vehicles from RHS. this add about 5 GB of dependencies to what is otherwise a very lightweight alternate faction.