### PR TITLE
Fix Typo in CfgMissionsEntry for RHSPKL/Saralite

### DIFF
--- a/tools/Builder/config.json
+++ b/tools/Builder/config.json
@@ -3,7 +3,7 @@
     "displayName": "Vindicta",
     "cfgMissionsClassName": "vindicta_missions",
     "combinedMissionsFolderName": "vindicta_missions",
-    
+
     "comment00": "List of files to copy during the build",
     "comment01": "'from' is relative to repository root, 'to' is relative to mission.sqm",
     "copyFiles": [
@@ -21,23 +21,23 @@
         },
         {
             "from": "configs\\cba_settings.sqf",
-            "to": "" 
+            "to": ""
         },
         {
             "from": "configs\\description.ext",
-            "to": "" 
+            "to": ""
         },
         {
             "from": "configs\\init.sqf",
-            "to": "" 
+            "to": ""
         },
         {
             "from": "configs\\onPlayerRespawn.sqf",
-            "to": "" 
+            "to": ""
         },
         {
             "from": "configs\\stringtable.xml",
-            "to": "" 
+            "to": ""
         }
     ],
 
@@ -93,7 +93,7 @@
         },
         {
             "folder": "Vindicta.saralite",
-            "CfgMissionsEntry": "vindicta_rhspkl",
+            "CfgMissionsEntry": "vindicta_saralite",
             "mapName": "saralite",
             "briefingName": "Vindicta - Southern Sahrani"
         },


### PR DESCRIPTION
Sadly #753 had a Typo in it, the CfgMissionsEntry for Saralite and RHSPKL was the same, resulting in Saralite winning and RHSPKL not being shown by current Version, DevBranch and or Workshop Version.

		class vindicta_rhspkl
		{
			briefingName="Vindicta - Prei Khmaoch Luong 0.53.43";
			directory="vindicta_missions\vindicta_rhspkl.rhspkl";
		};
		class vindicta_rhspkl
		{
			briefingName="Vindicta - Southern Sahrani 0.53.43";
			directory="vindicta_missions\vindicta_rhspkl.saralite";
		};