### PR TITLE
Disable new save game button correctly

### DIFF
--- a/src/UI/InGameMenu/InGameMenuTabSave.sqf
+++ b/src/UI/InGameMenu/InGameMenuTabSave.sqf
@@ -195,7 +195,7 @@ CLASS("InGameMenuTabSave", "DialogTabBase")
 			default {0}; // Error?
 		};
 
-		if (call misc_fnc_isAdminLocal) then {
+		if (call misc_fnc_isAdminLocal && CALLM0(gGameManager, "isGameModeInitialized")) then { // Only admin can save when the game is intialized
 			if (count T_GETV("recordData") > _saveGameLimit) then {
 				pr _newSaveBtn = T_CALLM1("findControl", "TAB_SAVE_BUTTON_NEW");
 				_newSaveBtn ctrlEnable false;


### PR DESCRIPTION
Fixes:

* When logged in as admin and the game is still uninitialized, the "new save game" is falsely enabled because of an incomplete if condition.