### PR TITLE
- Patch 0.4 (Enabled Dynamic Simulation)

### DIFF
--- a/Vindicta.eden/mission.sqm
+++ b/Vindicta.eden/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=525;
 	class ItemIDProvider
 	{
-		nextID=9995;
+		nextID=9999;
 	};
 	class MarkerIDProvider
 	{
@@ -16,14 +16,14 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=6388;
+		nextID=6634;
 	};
 	class Camera
 	{
-		pos[]={1128.3784,98.245277,11515.396};
-		dir[]={0.69486344,-0.29960707,-0.65377718};
-		up[]={0.21821183,0.95405877,-0.20530958};
-		aside[]={-0.68525368,-2.9907096e-007,-0.72831732};
+		pos[]={1121.7853,103.84307,11517.349};
+		dir[]={0.68506598,-0.48114544,-0.54698461};
+		up[]={0.37600088,0.87663823,-0.30021361};
+		aside[]={-0.6239568,2.9389048e-007,-0.78146756};
 	};
 };
 binarizationWanted=0;
@@ -607,6 +607,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1196;
 											type="Land_Hlaska";
@@ -623,6 +624,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1198;
 											type="Land_Hlaska";
@@ -639,6 +641,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1203;
 											type="Land_Hlaska";
@@ -648,17 +651,17 @@ class Mission
 											dataType="Object";
 											class PositionInfo
 											{
-												position[]={7540,162.39305,4225};
-												angles[]={0,6.15694,0};
+												position[]={7540,162.3927,4225};
+												angles[]={0,6.1569457,0};
 											};
 											side="Empty";
-											flags=4;
 											class Attributes
 											{
 												disableSimulation=1;
 											};
 											id=1199;
 											type="B_HMG_01_high_F";
+											atlOffset=6.904007;
 										};
 										class Item4
 										{
@@ -713,7 +716,7 @@ class Mission
 										};
 									};
 									id=1137;
-									atlOffset=6.6286011;
+									atlOffset=6.6285706;
 								};
 								class Item3
 								{
@@ -1806,7 +1809,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2212;
 									type="FirePlace_burning_F";
@@ -1823,7 +1826,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2210;
 									type="Land_CampingChair_V1_F";
@@ -1840,7 +1843,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2211;
 									type="Land_CampingChair_V1_folded_F";
@@ -1857,7 +1860,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2216;
 									type="Land_Wreck_HMMWV_F";
@@ -1869,13 +1872,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={7465,156.0979,4089.5};
-										angles[]={0.022996427,2.3351049,6.1509662};
+										angles[]={0.023003438,2.3351111,6.1509595};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2221;
 									type="Land_Wreck_HMMWV_F";
@@ -1892,7 +1895,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2230;
 									type="Land_Bench_01_F";
@@ -1909,7 +1912,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2231;
 									type="Land_Bench_01_F";
@@ -1926,7 +1929,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2232;
 									type="Land_Bench_01_F";
@@ -1942,7 +1945,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2233;
 									type="Land_Bench_01_F";
@@ -1959,7 +1962,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2236;
 									type="Land_Bench_01_F";
@@ -1976,7 +1979,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2218;
 									type="Land_Wreck_BMP2_F";
@@ -1994,7 +1997,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2219;
 									type="Land_Wreck_BMP2_F";
@@ -2011,7 +2014,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2220;
 									type="Land_Wreck_BRDM2_F";
@@ -2028,7 +2031,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2266;
 									type="Campfire_burning_F";
@@ -2045,7 +2048,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2267;
 									type="Campfire_burning_F";
@@ -2063,7 +2066,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2268;
 									type="Campfire_burning_F";
@@ -2080,7 +2083,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2269;
 									type="Campfire_burning_F";
@@ -2097,7 +2100,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2234;
 									type="FirePlace_burning_F";
@@ -2114,7 +2117,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2235;
 									type="FirePlace_burning_F";
@@ -2131,7 +2134,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2253;
 									type="FirePlace_burning_F";
@@ -2148,7 +2151,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2252;
 									type="Land_CampingChair_V1_F";
@@ -2165,7 +2168,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2255;
 									type="Land_CampingChair_V1_F";
@@ -2182,7 +2185,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2258;
 									type="Land_CampingChair_V1_F";
@@ -2200,7 +2203,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2260;
 									type="Land_CampingChair_V1_F";
@@ -2218,7 +2221,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2262;
 									type="Land_CampingChair_V1_F";
@@ -2235,7 +2238,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2264;
 									type="Land_CampingChair_V1_F";
@@ -2252,7 +2255,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2259;
 									type="Land_CampingChair_V1_folded_F";
@@ -2269,7 +2272,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2261;
 									type="Land_CampingChair_V1_folded_F";
@@ -2286,7 +2289,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2263;
 									type="Land_CampingChair_V1_folded_F";
@@ -2303,7 +2306,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2265;
 									type="Land_CampingChair_V1_folded_F";
@@ -2320,7 +2323,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2213;
 									type="Land_Wreck_Truck_F";
@@ -2337,7 +2340,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2215;
 									type="Land_Wreck_UAZ_F";
@@ -2354,7 +2357,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2214;
 									type="Land_Wreck_Ural_F";
@@ -2371,7 +2374,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2222;
 									type="Land_Wreck_T72_hull_F";
@@ -2389,7 +2392,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2224;
 									type="Land_Wreck_T72_hull_F";
@@ -2405,7 +2408,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2223;
 									type="Land_Wreck_T72_turret_F";
@@ -2421,7 +2424,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2225;
 									type="Land_Wreck_T72_turret_F";
@@ -2439,7 +2442,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2273;
 									type="Land_Bench_01_F";
@@ -2456,7 +2459,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2276;
 									type="Land_Bench_01_F";
@@ -2473,7 +2476,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2284;
 									type="Land_Bench_01_F";
@@ -2490,7 +2493,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2285;
 									type="Land_Bench_01_F";
@@ -2507,7 +2510,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2298;
 									type="Land_Bench_01_F";
@@ -2524,7 +2527,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2299;
 									type="Land_Bench_01_F";
@@ -2541,7 +2544,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2300;
 									type="Land_Bench_01_F";
@@ -2558,7 +2561,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2301;
 									type="Land_Bench_01_F";
@@ -2575,7 +2578,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2302;
 									type="Land_Bench_01_F";
@@ -2592,7 +2595,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2318;
 									type="Land_FieldToilet_F";
@@ -2609,7 +2612,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2319;
 									type="Land_FieldToilet_F";
@@ -2627,7 +2630,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2320;
 									type="Land_FieldToilet_F";
@@ -2645,7 +2648,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2321;
 									type="Land_FieldToilet_F";
@@ -2663,7 +2666,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2322;
 									type="Land_FieldToilet_F";
@@ -2681,7 +2684,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2323;
 									type="Land_FieldToilet_F";
@@ -2698,7 +2701,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2287;
 									type="FirePlace_burning_F";
@@ -2714,7 +2717,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2289;
 									type="FirePlace_burning_F";
@@ -2732,7 +2735,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2293;
 									type="FirePlace_burning_F";
@@ -2749,7 +2752,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2294;
 									type="FirePlace_burning_F";
@@ -2765,7 +2768,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2297;
 									type="FirePlace_burning_F";
@@ -2782,7 +2785,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2290;
 									type="Land_CampingChair_V1_F";
@@ -2799,7 +2802,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2291;
 									type="Land_CampingChair_V1_F";
@@ -2816,7 +2819,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2295;
 									type="Land_CampingChair_V1_F";
@@ -2833,7 +2836,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2352;
 									type="Land_CampingChair_V1_F";
@@ -2850,7 +2853,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2292;
 									type="Land_CampingChair_V1_folded_F";
@@ -2867,7 +2870,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2296;
 									type="Land_CampingChair_V1_folded_F";
@@ -2884,7 +2887,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2314;
 									type="Land_CampingChair_V1_folded_F";
@@ -2902,7 +2905,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2315;
 									type="Land_CampingChair_V1_folded_F";
@@ -2920,7 +2923,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2316;
 									type="Land_CampingChair_V1_folded_F";
@@ -2938,7 +2941,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2317;
 									type="Land_CampingChair_V1_folded_F";
@@ -2955,7 +2958,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2348;
 									type="Land_CampingChair_V1_folded_F";
@@ -2972,7 +2975,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2349;
 									type="Land_CampingChair_V1_folded_F";
@@ -2989,7 +2992,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2350;
 									type="Land_CampingChair_V1_folded_F";
@@ -3006,7 +3009,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2351;
 									type="Land_CampingChair_V1_folded_F";
@@ -3024,7 +3027,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2353;
 									type="Land_CampingChair_V1_folded_F";
@@ -3041,7 +3044,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2354;
 									type="Land_CampingChair_V1_folded_F";
@@ -3058,7 +3061,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2356;
 									type="Campfire_burning_F";
@@ -3076,7 +3079,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2357;
 									type="Land_CampingChair_V1_F";
@@ -3094,7 +3097,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2358;
 									type="Land_CampingChair_V1_F";
@@ -3111,7 +3114,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2359;
 									type="Land_CampingChair_V1_folded_F";
@@ -3129,7 +3132,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2360;
 									type="Land_CampingChair_V1_folded_F";
@@ -3146,7 +3149,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2355;
 									type="Land_TBox_F";
@@ -3163,7 +3166,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2367;
 									type="Land_Wreck_UAZ_F";
@@ -3180,7 +3183,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2818;
 									type="Land_FieldToilet_F";
@@ -3198,7 +3201,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2819;
 									type="Land_FieldToilet_F";
@@ -3216,7 +3219,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2822;
 									type="FirePlace_burning_F";
@@ -3233,7 +3236,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2823;
 									type="Land_CampingChair_V1_F";
@@ -3251,7 +3254,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2824;
 									type="Land_CampingChair_V1_folded_F";
@@ -3268,7 +3271,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2825;
 									type="Land_CampingChair_V1_folded_F";
@@ -3285,7 +3288,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3073;
 									type="Campfire_burning_F";
@@ -3303,7 +3306,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3074;
 									type="Land_CampingChair_V1_F";
@@ -3321,7 +3324,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3075;
 									type="Land_CampingChair_V1_F";
@@ -3339,7 +3342,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3076;
 									type="Land_CampingChair_V1_folded_F";
@@ -3356,7 +3359,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3077;
 									type="Land_Sun_chair_green_F";
@@ -3373,7 +3376,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3079;
 									type="Land_Sun_chair_green_F";
@@ -3390,7 +3393,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3083;
 									type="Land_Sun_chair_green_F";
@@ -3407,7 +3410,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3080;
 									type="Land_Sun_chair_green_F";
@@ -3424,18 +3427,18 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9989;
 									type="FirePlace_burning_F";
 								};
 							};
 							id=1776;
-							atlOffset=0.0016479492;
+							atlOffset=0.0017852783;
 						};
 					};
 					id=76;
-					atlOffset=0.73959351;
+					atlOffset=0.73965454;
 				};
 				class Item1
 				{
@@ -4283,6 +4286,7 @@ class Mission
 											side="Empty";
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1256;
 											type="Land_Hlaska";
@@ -4299,6 +4303,7 @@ class Mission
 											side="Empty";
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1257;
 											type="Land_Hlaska";
@@ -4315,6 +4320,7 @@ class Mission
 											side="Empty";
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1258;
 											type="Land_Hlaska";
@@ -4331,6 +4337,7 @@ class Mission
 											side="Empty";
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1259;
 											type="Land_Hlaska";
@@ -4688,7 +4695,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2389;
 									type="Land_Bench_01_F";
@@ -4705,7 +4712,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2392;
 									type="Land_Bench_01_F";
@@ -4722,7 +4729,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2393;
 									type="Land_Bench_01_F";
@@ -4739,7 +4746,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2418;
 									type="Land_Bench_01_F";
@@ -4756,7 +4763,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2419;
 									type="Land_Bench_01_F";
@@ -4773,7 +4780,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2380;
 									type="Campfire_burning_F";
@@ -4791,7 +4798,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2382;
 									type="Campfire_burning_F";
@@ -4808,7 +4815,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2383;
 									type="Campfire_burning_F";
@@ -4825,7 +4832,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2384;
 									type="Campfire_burning_F";
@@ -4843,7 +4850,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2420;
 									type="Campfire_burning_F";
@@ -4860,7 +4867,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2405;
 									type="Land_FieldToilet_F";
@@ -4878,7 +4885,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2406;
 									type="Land_FieldToilet_F";
@@ -4896,7 +4903,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2404;
 									type="FirePlace_burning_F";
@@ -4913,7 +4920,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2414;
 									type="FirePlace_burning_F";
@@ -4930,7 +4937,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2368;
 									type="Land_CampingChair_V1_F";
@@ -4947,7 +4954,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2371;
 									type="Land_CampingChair_V1_F";
@@ -4964,7 +4971,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2372;
 									type="Land_CampingChair_V1_F";
@@ -4982,7 +4989,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2374;
 									type="Land_CampingChair_V1_F";
@@ -4999,7 +5006,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2376;
 									type="Land_CampingChair_V1_F";
@@ -5016,7 +5023,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2401;
 									type="Land_CampingChair_V1_F";
@@ -5033,7 +5040,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2402;
 									type="Land_CampingChair_V1_F";
@@ -5050,7 +5057,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2409;
 									type="Land_CampingChair_V1_F";
@@ -5067,7 +5074,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2411;
 									type="Land_CampingChair_V1_F";
@@ -5085,7 +5092,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2421;
 									type="Land_CampingChair_V1_F";
@@ -5102,7 +5109,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2422;
 									type="Land_CampingChair_V1_F";
@@ -5120,7 +5127,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2369;
 									type="Land_CampingChair_V1_folded_F";
@@ -5137,7 +5144,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2370;
 									type="Land_CampingChair_V1_folded_F";
@@ -5154,7 +5161,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2373;
 									type="Land_CampingChair_V1_folded_F";
@@ -5171,7 +5178,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2375;
 									type="Land_CampingChair_V1_folded_F";
@@ -5188,7 +5195,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2377;
 									type="Land_CampingChair_V1_folded_F";
@@ -5205,7 +5212,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2403;
 									type="Land_CampingChair_V1_folded_F";
@@ -5222,7 +5229,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2415;
 									type="Land_CampingChair_V1_folded_F";
@@ -5239,7 +5246,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2423;
 									type="Land_CampingChair_V1_folded_F";
@@ -5256,7 +5263,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2386;
 									type="Land_RowBoat_V1_F";
@@ -5274,7 +5281,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2387;
 									type="Land_RowBoat_V2_F";
@@ -5291,7 +5298,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2388;
 									type="Land_RowBoat_V3_F";
@@ -5309,7 +5316,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2516;
 									type="FirePlace_burning_F";
@@ -5326,7 +5333,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2872;
 									type="Land_RowBoat_V1_F";
@@ -5344,7 +5351,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2873;
 									type="Land_RowBoat_V3_F";
@@ -5362,10 +5369,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2834;
 									type="Campfire_burning_F";
+									atlOffset=0.001411438;
 								};
 								class Item40
 								{
@@ -5379,7 +5387,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2866;
 									type="Campfire_burning_F";
@@ -5397,7 +5405,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2870;
 									type="Campfire_burning_F";
@@ -5415,7 +5423,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2871;
 									type="Campfire_burning_F";
@@ -5432,7 +5440,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2861;
 									type="Land_CampingChair_V1_F";
@@ -5449,7 +5457,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2862;
 									type="Land_CampingChair_V1_F";
@@ -5466,7 +5474,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2863;
 									type="Land_CampingChair_V1_F";
@@ -5483,7 +5491,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2864;
 									type="Land_CampingChair_V1_F";
@@ -5501,7 +5509,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2865;
 									type="Land_CampingChair_V1_F";
@@ -5518,7 +5526,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2829;
 									type="Land_Sun_chair_F";
@@ -5535,7 +5543,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2830;
 									type="Land_Sun_chair_F";
@@ -5552,7 +5560,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2845;
 									type="Land_Sun_chair_green_F";
@@ -5569,7 +5577,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2850;
 									type="Land_Sun_chair_green_F";
@@ -5586,7 +5594,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2851;
 									type="Land_Sun_chair_green_F";
@@ -5604,7 +5612,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2849;
 									type="Land_Sun_chair_green_F";
@@ -5622,7 +5630,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2859;
 									type="Land_Sun_chair_green_F";
@@ -5639,7 +5647,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3084;
 									type="Campfire_burning_F";
@@ -5657,7 +5665,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3085;
 									type="Land_CampingChair_V1_F";
@@ -5675,7 +5683,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3086;
 									type="Land_CampingChair_V1_F";
@@ -5693,18 +5701,18 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3087;
 									type="Land_CampingChair_V1_folded_F";
 								};
 							};
 							id=1777;
-							atlOffset=0.25690079;
+							atlOffset=0.2560997;
 						};
 					};
 					id=77;
-					atlOffset=1.4978256;
+					atlOffset=1.4969444;
 				};
 				class Item2
 				{
@@ -6248,6 +6256,7 @@ class Mission
 											side="Empty";
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1322;
 											type="Land_Hlaska";
@@ -6264,6 +6273,7 @@ class Mission
 											side="Empty";
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1323;
 											type="Land_Hlaska";
@@ -6280,6 +6290,7 @@ class Mission
 											side="Empty";
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1324;
 											type="Land_Hlaska";
@@ -6296,6 +6307,7 @@ class Mission
 											side="Empty";
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1326;
 											type="Land_Hlaska";
@@ -6306,8 +6318,8 @@ class Mission
 											dataType="Object";
 											class PositionInfo
 											{
-												position[]={9603.8926,242.6176,3073.8091};
-												angles[]={0,0.76576865,0};
+												position[]={9603.8926,242.61751,3073.8091};
+												angles[]={0,0.76576322,0};
 											};
 											side="Empty";
 											flags=4;
@@ -6317,7 +6329,7 @@ class Mission
 											};
 											id=1330;
 											type="B_HMG_01_high_F";
-											atlOffset=0.051467896;
+											atlOffset=0.051376343;
 										};
 										class Item5
 										{
@@ -7236,7 +7248,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2970;
 									type="Land_Bench_01_F";
@@ -7253,7 +7265,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2971;
 									type="Land_Bench_01_F";
@@ -7270,7 +7282,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2972;
 									type="Land_Bench_01_F";
@@ -7287,7 +7299,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3005;
 									type="Land_Bench_01_F";
@@ -7304,7 +7316,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3009;
 									type="Land_Bench_01_F";
@@ -7321,7 +7333,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3016;
 									type="Land_Bench_01_F";
@@ -7338,7 +7350,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3017;
 									type="Land_Bench_01_F";
@@ -7355,7 +7367,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2962;
 									type="Land_Campfire_F";
@@ -7372,7 +7384,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2948;
 									type="Campfire_burning_F";
@@ -7390,7 +7402,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2949;
 									type="Campfire_burning_F";
@@ -7408,7 +7420,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2950;
 									type="Campfire_burning_F";
@@ -7426,7 +7438,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2951;
 									type="Campfire_burning_F";
@@ -7443,7 +7455,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2954;
 									type="Campfire_burning_F";
@@ -7460,7 +7472,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2961;
 									type="Campfire_burning_F";
@@ -7477,7 +7489,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3018;
 									type="Campfire_burning_F";
@@ -7489,13 +7501,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={9596,226.31,2951.5};
-										angles[]={-0,5.988492,0.0018911054};
+										angles[]={0,5.988492,0.0018911054};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3039;
 									type="Campfire_burning_F";
@@ -7512,7 +7524,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3011;
 									type="Land_FieldToilet_F";
@@ -7522,18 +7534,18 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={9534.5,227.26868,2963};
-										angles[]={0.050954331,1.5697743,0};
+										position[]={9534.5,227.26825,2963.0002};
+										angles[]={0.050946157,1.5697666,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3013;
 									type="Land_FieldToilet_F";
-									atlOffset=-0.0015869141;
+									atlOffset=-0.0019989014;
 								};
 								class Item18
 								{
@@ -7547,7 +7559,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3015;
 									type="Land_FieldToilet_F";
@@ -7565,7 +7577,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2984;
 									type="FirePlace_burning_F";
@@ -7582,7 +7594,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2985;
 									type="FirePlace_burning_F";
@@ -7599,7 +7611,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2987;
 									type="FirePlace_burning_F";
@@ -7616,7 +7628,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2998;
 									type="FirePlace_burning_F";
@@ -7633,7 +7645,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3019;
 									type="FirePlace_burning_F";
@@ -7650,7 +7662,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3020;
 									type="FirePlace_burning_F";
@@ -7666,7 +7678,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3025;
 									type="FirePlace_burning_F";
@@ -7683,7 +7695,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2935;
 									type="Land_CampingChair_V1_F";
@@ -7701,7 +7713,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2936;
 									type="Land_CampingChair_V1_F";
@@ -7718,7 +7730,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2938;
 									type="Land_CampingChair_V1_F";
@@ -7736,7 +7748,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2939;
 									type="Land_CampingChair_V1_F";
@@ -7753,7 +7765,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2941;
 									type="Land_CampingChair_V1_F";
@@ -7770,7 +7782,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2942;
 									type="Land_CampingChair_V1_F";
@@ -7788,7 +7800,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2945;
 									type="Land_CampingChair_V1_F";
@@ -7805,7 +7817,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2946;
 									type="Land_CampingChair_V1_F";
@@ -7822,7 +7834,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2952;
 									type="Land_CampingChair_V1_F";
@@ -7839,7 +7851,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2953;
 									type="Land_CampingChair_V1_F";
@@ -7856,7 +7868,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2955;
 									type="Land_CampingChair_V1_F";
@@ -7873,7 +7885,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2957;
 									type="Land_CampingChair_V1_F";
@@ -7890,10 +7902,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2958;
 									type="Land_CampingChair_V1_F";
+									atlOffset=-0.0030975342;
 								};
 								class Item39
 								{
@@ -7907,7 +7920,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2959;
 									type="Land_CampingChair_V1_F";
@@ -7924,7 +7937,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2963;
 									type="Land_CampingChair_V1_F";
@@ -7941,7 +7954,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2964;
 									type="Land_CampingChair_V1_F";
@@ -7959,7 +7972,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2965;
 									type="Land_CampingChair_V1_F";
@@ -7977,7 +7990,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2966;
 									type="Land_CampingChair_V1_F";
@@ -7994,7 +8007,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2967;
 									type="Land_CampingChair_V1_F";
@@ -8012,7 +8025,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2968;
 									type="Land_CampingChair_V1_F";
@@ -8029,7 +8042,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3021;
 									type="Land_CampingChair_V1_F";
@@ -8046,7 +8059,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3022;
 									type="Land_CampingChair_V1_F";
@@ -8063,7 +8076,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3026;
 									type="Land_CampingChair_V1_F";
@@ -8080,7 +8093,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3027;
 									type="Land_CampingChair_V1_F";
@@ -8091,13 +8104,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={9595.999,226.59807,2949};
-										angles[]={-0,3.0712316,0.0018911054};
+										angles[]={0,3.0712316,0.0018911054};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3037;
 									type="Land_CampingChair_V1_F";
@@ -8108,13 +8121,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={9592.999,226.59232,2950};
-										angles[]={-0,4.1842279,0.0018911054};
+										angles[]={0,4.1842279,0.0018911054};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3038;
 									type="Land_CampingChair_V1_F";
@@ -8125,13 +8138,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={9592.999,226.59232,2952.5};
-										angles[]={-0,4.7432618,0.0018911054};
+										angles[]={0,4.7432618,0.0018911054};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3040;
 									type="Land_CampingChair_V1_F";
@@ -8148,7 +8161,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2937;
 									type="Land_CampingChair_V1_folded_F";
@@ -8165,7 +8178,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2940;
 									type="Land_CampingChair_V1_folded_F";
@@ -8182,7 +8195,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2944;
 									type="Land_CampingChair_V1_folded_F";
@@ -8199,7 +8212,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2947;
 									type="Land_CampingChair_V1_folded_F";
@@ -8216,7 +8229,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2956;
 									type="Land_CampingChair_V1_folded_F";
@@ -8233,7 +8246,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2960;
 									type="Land_CampingChair_V1_folded_F";
@@ -8250,7 +8263,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2969;
 									type="Land_CampingChair_V1_folded_F";
@@ -8268,7 +8281,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3023;
 									type="Land_CampingChair_V1_folded_F";
@@ -8285,7 +8298,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3024;
 									type="Land_CampingChair_V1_folded_F";
@@ -8302,7 +8315,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3028;
 									type="Land_CampingChair_V1_folded_F";
@@ -8319,7 +8332,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3029;
 									type="Land_CampingChair_V1_folded_F";
@@ -8336,7 +8349,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3030;
 									type="Land_Sun_chair_green_F";
@@ -8353,7 +8366,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3031;
 									type="Land_Sun_chair_green_F";
@@ -8370,7 +8383,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3036;
 									type="Land_Sun_chair_green_F";
@@ -8387,18 +8400,18 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3094;
 									type="Land_Sun_chair_green_F";
 								};
 							};
 							id=1778;
-							atlOffset=0.0075531006;
+							atlOffset=0.026947021;
 						};
 					};
 					id=59;
-					atlOffset=0.53800964;
+					atlOffset=0.548172;
 				};
 				class Item3
 				{
@@ -8835,16 +8848,18 @@ class Mission
 											dataType="Object";
 											class PositionInfo
 											{
-												position[]={4674.522,24.493439,10867.029};
-												angles[]={6.2162943,3.8693221,0.039973188};
+												position[]={4674.522,24.493542,10867.03};
+												angles[]={6.2162867,3.8693252,0.03996804};
 											};
 											side="Empty";
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=918;
 											type="Land_Hlaska";
+											atlOffset=1.9073486e-006;
 										};
 										class Item1
 										{
@@ -8858,6 +8873,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=922;
 											type="Land_Hlaska";
@@ -8874,6 +8890,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=924;
 											type="Land_Hlaska";
@@ -8891,6 +8908,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=928;
 											type="Land_Hlaska";
@@ -8907,6 +8925,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=932;
 											type="Land_Hlaska";
@@ -8923,6 +8942,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=934;
 											type="Land_Hlaska";
@@ -8939,6 +8959,7 @@ class Mission
 											side="Empty";
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=944;
 											type="Land_Hlaska";
@@ -8956,6 +8977,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=946;
 											type="Land_Hlaska";
@@ -11036,6 +11058,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
+										dynamicSimulation=1;
 									};
 									id=1742;
 									type="Land_Airport_Tower_F";
@@ -11053,11 +11076,79 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1744;
 									type="Land_FieldToilet_F";
 									atlOffset=-1.9073486e-006;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="DoorStates";
+											expression="['init',_this,_value] call bis_fnc_3DENAttributeDoorStates;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"ARRAY"
+														};
+													};
+													class value
+													{
+														items=3;
+														class Item0
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+														class Item1
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+														class Item2
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+													};
+												};
+											};
+										};
+										nAttributes=1;
+									};
 								};
 								class Item2
 								{
@@ -11071,11 +11162,79 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1745;
 									type="Land_FieldToilet_F";
 									atlOffset=-3.6239624e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="DoorStates";
+											expression="['init',_this,_value] call bis_fnc_3DENAttributeDoorStates;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"ARRAY"
+														};
+													};
+													class value
+													{
+														items=3;
+														class Item0
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+														class Item1
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+														class Item2
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+													};
+												};
+											};
+										};
+										nAttributes=1;
+									};
 								};
 								class Item3
 								{
@@ -11089,11 +11248,79 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1746;
 									type="Land_FieldToilet_F";
 									atlOffset=-3.6239624e-005;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="DoorStates";
+											expression="['init',_this,_value] call bis_fnc_3DENAttributeDoorStates;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"ARRAY"
+														};
+													};
+													class value
+													{
+														items=3;
+														class Item0
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+														class Item1
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+														class Item2
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+													};
+												};
+											};
+										};
+										nAttributes=1;
+									};
 								};
 								class Item4
 								{
@@ -11107,11 +11334,79 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1747;
 									type="Land_FieldToilet_F";
 									atlOffset=3.8146973e-006;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="DoorStates";
+											expression="['init',_this,_value] call bis_fnc_3DENAttributeDoorStates;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"ARRAY"
+														};
+													};
+													class value
+													{
+														items=3;
+														class Item0
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+														class Item1
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+														class Item2
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+													};
+												};
+											};
+										};
+										nAttributes=1;
+									};
 								};
 								class Item5
 								{
@@ -11125,7 +11420,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1819;
 									type="Land_Bench_01_F";
@@ -11142,10 +11437,78 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1820;
 									type="Land_FieldToilet_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="DoorStates";
+											expression="['init',_this,_value] call bis_fnc_3DENAttributeDoorStates;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"ARRAY"
+														};
+													};
+													class value
+													{
+														items=3;
+														class Item0
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+														class Item1
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+														class Item2
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+													};
+												};
+											};
+										};
+										nAttributes=1;
+									};
 								};
 								class Item7
 								{
@@ -11159,10 +11522,78 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1822;
 									type="Land_FieldToilet_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="DoorStates";
+											expression="['init',_this,_value] call bis_fnc_3DENAttributeDoorStates;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"ARRAY"
+														};
+													};
+													class value
+													{
+														items=3;
+														class Item0
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+														class Item1
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+														class Item2
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+													};
+												};
+											};
+										};
+										nAttributes=1;
+									};
 								};
 								class Item8
 								{
@@ -11176,10 +11607,78 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1823;
 									type="Land_FieldToilet_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="DoorStates";
+											expression="['init',_this,_value] call bis_fnc_3DENAttributeDoorStates;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"ARRAY"
+														};
+													};
+													class value
+													{
+														items=3;
+														class Item0
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+														class Item1
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+														class Item2
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+													};
+												};
+											};
+										};
+										nAttributes=1;
+									};
 								};
 								class Item9
 								{
@@ -11193,10 +11692,78 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1824;
 									type="Land_FieldToilet_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="DoorStates";
+											expression="['init',_this,_value] call bis_fnc_3DENAttributeDoorStates;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"ARRAY"
+														};
+													};
+													class value
+													{
+														items=3;
+														class Item0
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+														class Item1
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+														class Item2
+														{
+															class data
+															{
+																class type
+																{
+																	type[]=
+																	{
+																		"SCALAR"
+																	};
+																};
+																value=0;
+															};
+														};
+													};
+												};
+											};
+										};
+										nAttributes=1;
+									};
 								};
 								class Item10
 								{
@@ -11210,6 +11777,7 @@ class Mission
 									flags=1;
 									class Attributes
 									{
+										dynamicSimulation=1;
 									};
 									id=1830;
 									type="Land_Hangar_F";
@@ -11227,6 +11795,7 @@ class Mission
 									flags=1;
 									class Attributes
 									{
+										dynamicSimulation=1;
 									};
 									id=1833;
 									type="Land_Hangar_F";
@@ -11244,6 +11813,7 @@ class Mission
 									flags=1;
 									class Attributes
 									{
+										dynamicSimulation=1;
 									};
 									id=1834;
 									type="Land_Hangar_F";
@@ -11261,7 +11831,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1839;
 									type="Land_ChairPlastic_F";
@@ -11278,7 +11848,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1879;
 									type="TargetP_Inf_Acc2_F";
@@ -11295,7 +11865,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1882;
 									type="TargetP_Inf_Acc2_F";
@@ -11312,7 +11882,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1885;
 									type="TargetP_Inf_Acc2_F";
@@ -11329,7 +11899,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1890;
 									type="Land_Shooting_range";
@@ -11346,7 +11916,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1891;
 									type="Land_Shooting_range";
@@ -11363,7 +11933,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1873;
 									type="Land_Shooting_range";
@@ -11380,7 +11950,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1869;
 									type="Land_Shooting_range";
@@ -11391,13 +11961,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4851,24.716438,12025.5};
-										angles[]={0,0.026222257,0};
+										angles[]={0,0.026214845,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1892;
 									type="Land_Shooting_range";
@@ -11414,7 +11984,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1893;
 									type="Land_Shooting_range";
@@ -11431,7 +12001,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1842;
 									type="Land_Sun_chair_F";
@@ -11448,7 +12018,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1940;
 									type="Land_Bench_01_F";
@@ -11465,7 +12035,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1949;
 									type="Land_Bench_01_F";
@@ -11482,7 +12052,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1950;
 									type="Land_Bench_01_F";
@@ -11499,7 +12069,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1951;
 									type="Land_Bench_01_F";
@@ -11516,7 +12086,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1952;
 									type="Land_Bench_01_F";
@@ -11533,7 +12103,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1953;
 									type="Land_Bench_01_F";
@@ -11550,7 +12120,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1955;
 									type="Land_Bench_01_F";
@@ -11567,7 +12137,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1956;
 									type="Land_Bench_01_F";
@@ -11583,7 +12153,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1967;
 									type="Campfire_burning_F";
@@ -11600,7 +12170,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1989;
 									type="Land_ChairPlastic_F";
@@ -11617,7 +12187,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1981;
 									type="Land_CampingChair_V1_folded_F";
@@ -11634,7 +12204,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1982;
 									type="Land_CampingChair_V1_folded_F";
@@ -11650,7 +12220,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1994;
 									type="Land_Laptop_02_unfolded_F";
@@ -11668,7 +12238,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1992;
 									type="Land_TBox_F";
@@ -11685,7 +12255,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1996;
 									type="Land_Bench_01_F";
@@ -11702,7 +12272,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1997;
 									type="Land_Bench_01_F";
@@ -11719,7 +12289,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=1998;
 									type="Land_Bench_01_F";
@@ -11736,7 +12306,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2000;
 									type="Land_Bench_01_F";
@@ -11752,7 +12322,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2025;
 									type="TargetP_Inf_Acc2_F";
@@ -11770,7 +12340,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2027;
 									type="TargetP_Inf_Acc2_F";
@@ -11788,7 +12358,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2029;
 									type="Land_ChairPlastic_F";
@@ -11805,7 +12375,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2032;
 									type="Land_ChairPlastic_F";
@@ -11822,7 +12392,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2037;
 									type="TargetP_Inf_Acc2_F";
@@ -11839,7 +12409,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2039;
 									type="TargetP_Inf_Acc2_F";
@@ -11857,7 +12427,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2041;
 									type="TargetP_Inf_Acc2_F";
@@ -11875,7 +12445,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2018;
 									type="Land_CampingChair_V2_F";
@@ -11892,7 +12462,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2019;
 									type="Land_CampingChair_V2_F";
@@ -11909,7 +12479,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2020;
 									type="Land_CampingChair_V2_F";
@@ -11926,7 +12496,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2010;
 									type="Land_CampingChair_V1_F";
@@ -11943,7 +12513,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2011;
 									type="Land_CampingChair_V1_F";
@@ -11960,7 +12530,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2012;
 									type="Land_CampingChair_V1_F";
@@ -11977,7 +12547,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2013;
 									type="Land_CampingChair_V1_F";
@@ -11994,7 +12564,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2021;
 									type="Land_CampingChair_V1_F";
@@ -12011,7 +12581,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2022;
 									type="Land_CampingChair_V1_folded_F";
@@ -12028,7 +12598,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2028;
 									type="Land_CampingChair_V1_folded_F";
@@ -12045,7 +12615,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2061;
 									type="Land_Bench_01_F";
@@ -12062,7 +12632,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2052;
 									type="FirePlace_burning_F";
@@ -12078,7 +12648,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2053;
 									type="FirePlace_burning_F";
@@ -12094,7 +12664,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2054;
 									type="FirePlace_burning_F";
@@ -12111,7 +12681,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2055;
 									type="FirePlace_burning_F";
@@ -12127,7 +12697,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2060;
 									type="FirePlace_burning_F";
@@ -12144,7 +12714,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2044;
 									type="Land_CampingChair_V1_F";
@@ -12161,7 +12731,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2045;
 									type="Land_CampingChair_V1_F";
@@ -12178,7 +12748,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2046;
 									type="Land_CampingChair_V1_F";
@@ -12195,7 +12765,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2047;
 									type="Land_CampingChair_V1_F";
@@ -12212,7 +12782,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2048;
 									type="Land_CampingChair_V1_F";
@@ -12229,7 +12799,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2049;
 									type="Land_CampingChair_V1_F";
@@ -12246,7 +12816,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2050;
 									type="Land_CampingChair_V1_F";
@@ -12263,7 +12833,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2051;
 									type="Land_CampingChair_V1_F";
@@ -12280,7 +12850,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2056;
 									type="Land_CampingChair_V1_F";
@@ -12297,7 +12867,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2057;
 									type="Land_CampingChair_V1_F";
@@ -12314,7 +12884,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2058;
 									type="Land_CampingChair_V1_F";
@@ -12331,7 +12901,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2059;
 									type="Land_CampingChair_V1_F";
@@ -12348,7 +12918,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2064;
 									type="Land_CampingChair_V1_F";
@@ -12365,7 +12935,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2066;
 									type="Land_CampingChair_V1_F";
@@ -12382,7 +12952,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2067;
 									type="Land_CampingChair_V1_F";
@@ -12400,7 +12970,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2068;
 									type="Land_CampingChair_V1_F";
@@ -12417,7 +12987,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2069;
 									type="Land_CampingChair_V1_F";
@@ -12435,7 +13005,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2071;
 									type="Land_CampingChair_V1_F";
@@ -12453,7 +13023,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2072;
 									type="Land_CampingChair_V1_F";
@@ -12470,7 +13040,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2062;
 									type="Land_CampingChair_V1_folded_F";
@@ -12487,7 +13057,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2063;
 									type="Land_CampingChair_V1_folded_F";
@@ -12504,7 +13074,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2065;
 									type="Land_CampingChair_V1_folded_F";
@@ -12521,7 +13091,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2070;
 									type="Land_CampingChair_V1_folded_F";
@@ -12538,7 +13108,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2074;
 									type="Land_CampingChair_V1_folded_F";
@@ -12555,7 +13125,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2102;
 									type="Land_CampingChair_V2_F";
@@ -12572,7 +13142,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2103;
 									type="Land_CampingChair_V2_F";
@@ -12589,7 +13159,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2090;
 									type="Campfire_burning_F";
@@ -12607,7 +13177,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2091;
 									type="Campfire_burning_F";
@@ -12625,7 +13195,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2092;
 									type="Campfire_burning_F";
@@ -12643,7 +13213,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2093;
 									type="Campfire_burning_F";
@@ -12661,7 +13231,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2094;
 									type="Campfire_burning_F";
@@ -12678,7 +13248,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2095;
 									type="Campfire_burning_F";
@@ -12696,7 +13266,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2097;
 									type="Campfire_burning_F";
@@ -12713,7 +13283,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2108;
 									type="Campfire_burning_F";
@@ -12730,7 +13300,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2119;
 									type="Campfire_burning_F";
@@ -12748,7 +13318,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2098;
 									type="FirePlace_burning_F";
@@ -12765,7 +13335,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2099;
 									type="FirePlace_burning_F";
@@ -12781,7 +13351,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2100;
 									type="FirePlace_burning_F";
@@ -12797,7 +13367,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2101;
 									type="FirePlace_burning_F";
@@ -12813,7 +13383,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2106;
 									type="FirePlace_burning_F";
@@ -12830,7 +13400,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2107;
 									type="FirePlace_burning_F";
@@ -12847,7 +13417,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2075;
 									type="Land_CampingChair_V1_F";
@@ -12864,7 +13434,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2076;
 									type="Land_CampingChair_V1_F";
@@ -12881,7 +13451,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2079;
 									type="Land_CampingChair_V1_F";
@@ -12898,7 +13468,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2080;
 									type="Land_CampingChair_V1_F";
@@ -12915,7 +13485,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2081;
 									type="Land_CampingChair_V1_F";
@@ -12932,7 +13502,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2082;
 									type="Land_CampingChair_V1_F";
@@ -12949,7 +13519,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2084;
 									type="Land_CampingChair_V1_F";
@@ -12966,7 +13536,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2085;
 									type="Land_CampingChair_V1_F";
@@ -12984,7 +13554,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2087;
 									type="Land_CampingChair_V1_F";
@@ -13002,7 +13572,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2088;
 									type="Land_CampingChair_V1_F";
@@ -13020,7 +13590,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2109;
 									type="Land_CampingChair_V1_F";
@@ -13037,7 +13607,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2110;
 									type="Land_CampingChair_V1_F";
@@ -13054,7 +13624,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2111;
 									type="Land_CampingChair_V1_F";
@@ -13071,7 +13641,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2117;
 									type="Land_CampingChair_V1_F";
@@ -13089,7 +13659,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2118;
 									type="Land_CampingChair_V1_F";
@@ -13107,7 +13677,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2077;
 									type="Land_CampingChair_V1_folded_F";
@@ -13124,7 +13694,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2078;
 									type="Land_CampingChair_V1_folded_F";
@@ -13141,7 +13711,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2083;
 									type="Land_CampingChair_V1_folded_F";
@@ -13158,7 +13728,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2086;
 									type="Land_CampingChair_V1_folded_F";
@@ -13175,7 +13745,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2089;
 									type="Land_CampingChair_V1_folded_F";
@@ -13192,7 +13762,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2112;
 									type="Land_CampingChair_V1_folded_F";
@@ -13209,7 +13779,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2121;
 									type="Land_CampingChair_V1_folded_F";
@@ -13226,7 +13796,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2123;
 									type="Land_CampingChair_V1_folded_F";
@@ -13243,7 +13813,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2156;
 									type="Campfire_burning_F";
@@ -13260,7 +13830,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2157;
 									type="Campfire_burning_F";
@@ -13277,7 +13847,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2158;
 									type="Land_CampingChair_V1_F";
@@ -13294,7 +13864,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2159;
 									type="Land_CampingChair_V1_F";
@@ -13311,7 +13881,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2160;
 									type="Land_CampingChair_V1_F";
@@ -13328,7 +13898,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2163;
 									type="Land_CampingChair_V1_F";
@@ -13345,7 +13915,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2164;
 									type="Land_CampingChair_V1_F";
@@ -13363,7 +13933,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2165;
 									type="Land_CampingChair_V1_F";
@@ -13380,7 +13950,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2168;
 									type="Land_CampingChair_V1_F";
@@ -13397,7 +13967,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2161;
 									type="Land_CampingChair_V1_folded_F";
@@ -13414,7 +13984,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2162;
 									type="Land_CampingChair_V1_folded_F";
@@ -13431,7 +14001,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2166;
 									type="Land_CampingChair_V1_folded_F";
@@ -13448,30 +14018,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2167;
 									type="Land_CampingChair_V1_folded_F";
 								};
 								class Item142
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={4862,24.913897,10927.5};
-										angles[]={0,0,6.2641892};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-										disableSimulation=1;
-									};
-									id=2173;
-									type="Land_Campfire_F";
-									atlOffset=1.5258789e-005;
-								};
-								class Item143
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13483,12 +14035,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2171;
 									type="Campfire_burning_F";
 								};
-								class Item144
+								class Item143
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13500,13 +14052,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2169;
 									type="Land_CampingChair_V1_F";
 									atlOffset=-1.335144e-005;
 								};
-								class Item145
+								class Item144
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13518,13 +14070,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2172;
 									type="Land_CampingChair_V1_F";
 									atlOffset=-3.8146973e-006;
 								};
-								class Item146
+								class Item145
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13536,12 +14088,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2174;
 									type="Land_CampingChair_V1_F";
 								};
-								class Item147
+								class Item146
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13553,12 +14105,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2175;
 									type="Land_CampingChair_V1_F";
 								};
-								class Item148
+								class Item147
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13570,12 +14122,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2170;
 									type="Land_CampingChair_V1_folded_F";
 								};
-								class Item149
+								class Item148
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13587,12 +14139,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2176;
 									type="Land_CampingChair_V1_folded_F";
 								};
-								class Item150
+								class Item149
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13604,29 +14156,29 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2177;
 									type="Land_CampingChair_V1_folded_F";
 								};
-								class Item151
+								class Item150
 								{
 									dataType="Object";
 									class PositionInfo
 									{
 										position[]={4840.5,25.579866,12072};
-										angles[]={6.2771854,1.9824225,0};
+										angles[]={6.277185,1.9824224,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2199;
 									type="Land_Wreck_HMMWV_F";
 								};
-								class Item152
+								class Item151
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13638,12 +14190,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2197;
 									type="Land_Wreck_BMP2_F";
 								};
-								class Item153
+								class Item152
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13655,12 +14207,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2209;
 									type="Land_Wreck_BMP2_F";
 								};
-								class Item154
+								class Item153
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13672,12 +14224,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2198;
 									type="Land_Wreck_BRDM2_F";
 								};
-								class Item155
+								class Item154
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13689,12 +14241,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2200;
 									type="Land_Wreck_Skodovka_F";
 								};
-								class Item156
+								class Item155
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13706,12 +14258,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2202;
 									type="Land_Wreck_UAZ_F";
 								};
-								class Item157
+								class Item156
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13723,12 +14275,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2201;
 									type="Land_Wreck_Ural_F";
 								};
-								class Item158
+								class Item157
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13740,12 +14292,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2205;
 									type="Land_Wreck_T72_hull_F";
 								};
-								class Item159
+								class Item158
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13757,12 +14309,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2207;
 									type="Land_Wreck_T72_hull_F";
 								};
-								class Item160
+								class Item159
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13773,13 +14325,13 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2206;
 									type="Land_Wreck_T72_turret_F";
 									atlOffset=1.20471;
 								};
-								class Item161
+								class Item160
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13790,13 +14342,13 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2208;
 									type="Land_Wreck_T72_turret_F";
 									atlOffset=1.2376995;
 								};
-								class Item162
+								class Item161
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13808,12 +14360,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2715;
 									type="TargetP_Inf2_Acc2_F";
 								};
-								class Item163
+								class Item162
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13825,12 +14377,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2716;
 									type="TargetP_Inf2_Acc2_F";
 								};
-								class Item164
+								class Item163
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13842,12 +14394,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2717;
 									type="TargetP_Inf2_Acc2_F";
 								};
-								class Item165
+								class Item164
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13859,12 +14411,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2718;
 									type="TargetP_Inf2_Acc2_F";
 								};
-								class Item166
+								class Item165
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13876,12 +14428,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2722;
 									type="TargetP_Inf2_Acc2_F";
 								};
-								class Item167
+								class Item166
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13893,12 +14445,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2723;
 									type="TargetP_Inf2_Acc2_F";
 								};
-								class Item168
+								class Item167
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13910,12 +14462,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2724;
 									type="TargetP_Inf2_Acc2_F";
 								};
-								class Item169
+								class Item168
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13926,12 +14478,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=2725;
 									type="FirePlace_burning_F";
 								};
-								class Item170
+								class Item169
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13943,12 +14495,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3053;
 									type="Land_Sun_chair_green_F";
 								};
-								class Item171
+								class Item170
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13960,12 +14512,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3054;
 									type="Land_Sun_chair_green_F";
 								};
-								class Item172
+								class Item171
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13977,12 +14529,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3049;
 									type="Land_Sun_chair_green_F";
 								};
-								class Item173
+								class Item172
 								{
 									dataType="Object";
 									class PositionInfo
@@ -13994,12 +14546,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3041;
 									type="Land_Sun_chair_green_F";
 								};
-								class Item174
+								class Item173
 								{
 									dataType="Object";
 									class PositionInfo
@@ -14010,12 +14562,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3066;
 									type="Campfire_burning_F";
 								};
-								class Item175
+								class Item174
 								{
 									dataType="Object";
 									class PositionInfo
@@ -14026,12 +14578,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3069;
 									type="FirePlace_burning_F";
 								};
-								class Item176
+								class Item175
 								{
 									dataType="Object";
 									class PositionInfo
@@ -14043,22 +14595,40 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9988;
 									type="FirePlace_burning_F";
 								};
+								class Item176
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={4862.3335,24.907558,10927.051};
+										angles[]={0,0,6.2641959};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										dynamicSimulation=1;
+									};
+									id=9997;
+									type="Campfire_burning_F";
+									atlOffset=1.9073486e-006;
+								};
 							};
 							id=1738;
-							atlOffset=0.00066566467;
+							atlOffset=-0.044412613;
 						};
 					};
 					id=547;
-					atlOffset=-0.042404175;
+					atlOffset=-0.12149811;
 				};
 			};
 			id=49;
-			atlOffset=-18.725403;
+			atlOffset=-38.779182;
 		};
 		class Item1
 		{
@@ -14341,7 +14911,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5285;
 									type="Land_Wreck_BMP2_F";
@@ -14359,11 +14929,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5291;
 									type="Campfire_burning_F";
-									atlOffset=-0.00019645691;
+									atlOffset=-9.5367432e-007;
 								};
 								class Item2
 								{
@@ -14377,7 +14947,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5295;
 									type="FirePlace_burning_F";
@@ -14395,11 +14965,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5297;
 									type="FirePlace_burning_F";
-									atlOffset=0.025733232;
+									atlOffset=0.025665998;
 								};
 								class Item4
 								{
@@ -14413,7 +14983,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5298;
 									type="FirePlace_burning_F";
@@ -14431,7 +15001,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5300;
 									type="FirePlace_burning_F";
@@ -14449,7 +15019,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5302;
 									type="FirePlace_burning_F";
@@ -14467,7 +15037,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5304;
 									type="FirePlace_burning_F";
@@ -14485,7 +15055,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5306;
 									type="FirePlace_burning_F";
@@ -14502,7 +15072,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5308;
 									type="FirePlace_burning_F";
@@ -14520,7 +15090,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5310;
 									type="FirePlace_burning_F";
@@ -14538,7 +15108,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5312;
 									type="FirePlace_burning_F";
@@ -14556,7 +15126,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5315;
 									type="FirePlace_burning_F";
@@ -14574,7 +15144,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5250;
 									type="Land_CampingChair_V1_F";
@@ -14591,7 +15161,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5256;
 									type="Land_CampingChair_V1_F";
@@ -14609,7 +15179,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5262;
 									type="Land_CampingChair_V1_F";
@@ -14627,7 +15197,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5263;
 									type="Land_CampingChair_V1_F";
@@ -14645,7 +15215,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5268;
 									type="Land_CampingChair_V1_F";
@@ -14663,7 +15233,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5269;
 									type="Land_CampingChair_V1_F";
@@ -14681,11 +15251,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5272;
 									type="Land_CampingChair_V1_F";
-									atlOffset=0.025507331;
+									atlOffset=0.025007129;
 								};
 								class Item20
 								{
@@ -14699,7 +15269,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5278;
 									type="Land_CampingChair_V1_F";
@@ -14717,7 +15287,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5279;
 									type="Land_CampingChair_V1_F";
@@ -14735,7 +15305,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5281;
 									type="Land_CampingChair_V1_F";
@@ -14753,7 +15323,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5282;
 									type="Land_CampingChair_V1_F";
@@ -14771,7 +15341,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5284;
 									type="Land_CampingChair_V1_F";
@@ -14789,7 +15359,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5289;
 									type="Land_CampingChair_V1_F";
@@ -14807,11 +15377,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5290;
 									type="Land_CampingChair_V1_F";
-									atlOffset=6.2942505e-005;
+									atlOffset=6.3896179e-005;
 								};
 								class Item27
 								{
@@ -14825,7 +15395,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5251;
 									type="Land_CampingChair_V1_folded_F";
@@ -14842,7 +15412,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5257;
 									type="Land_CampingChair_V1_folded_F";
@@ -14860,7 +15430,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5273;
 									type="Land_CampingChair_V1_folded_F";
@@ -14878,7 +15448,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5280;
 									type="Land_CampingChair_V1_folded_F";
@@ -14896,7 +15466,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5283;
 									type="Land_CampingChair_V1_folded_F";
@@ -14914,7 +15484,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5287;
 									type="Land_CampingChair_V1_folded_F";
@@ -14932,6 +15502,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
+										dynamicSimulation=1;
 									};
 									id=5212;
 									type="Land_LifeguardTower_01_F";
@@ -14949,6 +15520,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
+										dynamicSimulation=1;
 									};
 									id=5213;
 									type="Land_LifeguardTower_01_F";
@@ -14966,7 +15538,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5214;
 									type="Land_Sun_chair_F";
@@ -14984,7 +15556,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5215;
 									type="Land_Sun_chair_F";
@@ -15002,7 +15574,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5216;
 									type="Land_Sun_chair_F";
@@ -15020,7 +15592,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5217;
 									type="Land_Sun_chair_F";
@@ -15038,7 +15610,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5218;
 									type="Land_Sun_chair_F";
@@ -15056,7 +15628,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5219;
 									type="Land_Sun_chair_F";
@@ -15074,7 +15646,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5220;
 									type="Land_Sun_chair_F";
@@ -15092,7 +15664,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5221;
 									type="Land_Sun_chair_F";
@@ -15110,7 +15682,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5222;
 									type="Land_Sun_chair_F";
@@ -15127,7 +15699,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5223;
 									type="Land_Sun_chair_F";
@@ -15144,7 +15716,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5224;
 									type="Land_Sun_chair_F";
@@ -15162,7 +15734,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5225;
 									type="Land_Sun_chair_F";
@@ -15180,7 +15752,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5226;
 									type="Land_Sunshade_F";
@@ -15197,7 +15769,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5227;
 									type="Land_Sunshade_F";
@@ -15215,7 +15787,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5228;
 									type="Land_Sunshade_F";
@@ -15233,7 +15805,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5229;
 									type="Land_Sunshade_F";
@@ -15251,7 +15823,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5230;
 									type="Land_Sunshade_F";
@@ -15269,7 +15841,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5231;
 									type="Land_Sunshade_F";
@@ -15287,11 +15859,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5245;
 									type="Land_Sunshade_01_F";
-									atlOffset=0.047340035;
+									atlOffset=0.047340155;
 								};
 								class Item54
 								{
@@ -15305,7 +15877,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5233;
 									type="Land_Sunshade_03_F";
@@ -15323,7 +15895,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5240;
 									type="Land_Sunshade_03_F";
@@ -15340,7 +15912,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5237;
 									type="Land_Sunshade_04_F";
@@ -15358,7 +15930,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5243;
 									type="Land_Sunshade_04_F";
@@ -15376,7 +15948,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5292;
 									type="Land_ToiletBox_F";
@@ -15394,7 +15966,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5318;
 									type="Land_Wreck_BMP2_F";
@@ -15412,7 +15984,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5319;
 									type="Land_Wreck_BRDM2_F";
@@ -15430,7 +16002,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5316;
 									type="Land_UWreck_FishingBoat_F";
@@ -15448,7 +16020,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5320;
 									type="Land_Wreck_T72_hull_F";
@@ -15465,7 +16037,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5321;
 									type="Land_Wreck_T72_turret_F";
@@ -15483,7 +16055,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5357;
 									type="Land_Wreck_T72_hull_F";
@@ -15500,7 +16072,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5358;
 									type="Land_Wreck_T72_turret_F";
@@ -15518,7 +16090,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5333;
 									type="Land_BeachBooth_01_F";
@@ -15536,7 +16108,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5335;
 									type="Land_BeachBooth_01_F";
@@ -15554,7 +16126,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5336;
 									type="Land_BeachBooth_01_F";
@@ -15572,7 +16144,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5381;
 									type="Land_Bench_01_F";
@@ -15590,7 +16162,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5415;
 									type="Land_Bench_01_F";
@@ -15608,7 +16180,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5491;
 									type="Land_Bench_01_F";
@@ -15626,7 +16198,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5496;
 									type="Land_Bench_01_F";
@@ -15644,7 +16216,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5505;
 									type="Land_Bench_01_F";
@@ -15662,7 +16234,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5506;
 									type="Land_Bench_01_F";
@@ -15680,7 +16252,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5540;
 									type="Land_Bench_01_F";
@@ -15698,7 +16270,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5392;
 									type="Land_Wreck_BMP2_F";
@@ -15716,7 +16288,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5399;
 									type="Land_Wreck_BRDM2_F";
@@ -15734,7 +16306,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5328;
 									type="Campfire_burning_F";
@@ -15752,7 +16324,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5348;
 									type="Campfire_burning_F";
@@ -15770,7 +16342,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5365;
 									type="Campfire_burning_F";
@@ -15788,7 +16360,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5366;
 									type="Campfire_burning_F";
@@ -15806,7 +16378,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5378;
 									type="Campfire_burning_F";
@@ -15824,7 +16396,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5379;
 									type="Campfire_burning_F";
@@ -15842,7 +16414,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5388;
 									type="Campfire_burning_F";
@@ -15860,7 +16432,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5398;
 									type="Campfire_burning_F";
@@ -15878,7 +16450,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5403;
 									type="Campfire_burning_F";
@@ -15896,7 +16468,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5416;
 									type="Campfire_burning_F";
@@ -15914,7 +16486,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5428;
 									type="Campfire_burning_F";
@@ -15932,7 +16504,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5447;
 									type="Campfire_burning_F";
@@ -15950,7 +16522,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5454;
 									type="Campfire_burning_F";
@@ -15968,7 +16540,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5455;
 									type="Campfire_burning_F";
@@ -15986,7 +16558,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5468;
 									type="Campfire_burning_F";
@@ -16004,7 +16576,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5472;
 									type="Campfire_burning_F";
@@ -16021,7 +16593,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5495;
 									type="Campfire_burning_F";
@@ -16039,7 +16611,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5500;
 									type="Campfire_burning_F";
@@ -16057,7 +16629,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5566;
 									type="Campfire_burning_F";
@@ -16075,7 +16647,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5412;
 									type="Land_ChairWood_F";
@@ -16092,7 +16664,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5413;
 									type="Land_ChairWood_F";
@@ -16109,7 +16681,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5414;
 									type="Land_ChairWood_F";
@@ -16127,7 +16699,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5436;
 									type="Land_ChairWood_F";
@@ -16144,7 +16716,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5508;
 									type="Land_ChairWood_F";
@@ -16162,7 +16734,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5509;
 									type="Land_ChairWood_F";
@@ -16180,7 +16752,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5513;
 									type="Land_ChairWood_F";
@@ -16197,7 +16769,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5514;
 									type="Land_ChairWood_F";
@@ -16215,7 +16787,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5524;
 									type="Land_ChairWood_F";
@@ -16233,7 +16805,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5549;
 									type="Land_ChairWood_F";
@@ -16251,7 +16823,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5550;
 									type="Land_ChairWood_F";
@@ -16268,7 +16840,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5553;
 									type="Land_ChairWood_F";
@@ -16286,11 +16858,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5554;
 									type="Land_ChairWood_F";
-									atlOffset=0.00016784668;
+									atlOffset=0.00011634827;
 								};
 								class Item110
 								{
@@ -16298,13 +16870,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4665.0063,17.545971,10741.449};
-										angles[]={6.2826972,5.7394853,-0};
+										angles[]={6.2826972,5.7394853,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5568;
 									type="Land_ChairWood_F";
@@ -16316,13 +16888,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4667.96,17.546118,10741.976};
-										angles[]={6.2826972,6.2074227,-0};
+										angles[]={6.2826972,6.2074227,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5569;
 									type="Land_ChairWood_F";
@@ -16339,7 +16911,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5332;
 									type="FirePlace_burning_F";
@@ -16356,7 +16928,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5344;
 									type="FirePlace_burning_F";
@@ -16374,7 +16946,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5442;
 									type="FirePlace_burning_F";
@@ -16392,7 +16964,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5443;
 									type="FirePlace_burning_F";
@@ -16409,7 +16981,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5444;
 									type="FirePlace_burning_F";
@@ -16427,7 +16999,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5445;
 									type="FirePlace_burning_F";
@@ -16444,7 +17016,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5501;
 									type="FirePlace_burning_F";
@@ -16461,7 +17033,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5507;
 									type="FirePlace_burning_F";
@@ -16478,7 +17050,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5512;
 									type="FirePlace_burning_F";
@@ -16496,7 +17068,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5515;
 									type="FirePlace_burning_F";
@@ -16513,7 +17085,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5551;
 									type="FirePlace_burning_F";
@@ -16530,7 +17102,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5555;
 									type="FirePlace_burning_F";
@@ -16541,13 +17113,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4667.4951,17.593491,10738.897};
-										angles[]={6.2826972,6.1068559,-0};
+										angles[]={6.2826972,6.1068559,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5567;
 									type="FirePlace_burning_F";
@@ -16564,7 +17136,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5329;
 									type="Land_CampingChair_V1_F";
@@ -16582,7 +17154,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5330;
 									type="Land_CampingChair_V1_F";
@@ -16600,7 +17172,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5343;
 									type="Land_CampingChair_V1_F";
@@ -16617,7 +17189,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5349;
 									type="Land_CampingChair_V1_F";
@@ -16635,7 +17207,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5350;
 									type="Land_CampingChair_V1_F";
@@ -16653,7 +17225,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5351;
 									type="Land_CampingChair_V1_F";
@@ -16671,7 +17243,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5352;
 									type="Land_CampingChair_V1_F";
@@ -16689,7 +17261,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5368;
 									type="Land_CampingChair_V1_F";
@@ -16707,7 +17279,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5369;
 									type="Land_CampingChair_V1_F";
@@ -16725,7 +17297,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5370;
 									type="Land_CampingChair_V1_F";
@@ -16743,7 +17315,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5376;
 									type="Land_CampingChair_V1_F";
@@ -16761,7 +17333,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5382;
 									type="Land_CampingChair_V1_F";
@@ -16779,7 +17351,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5383;
 									type="Land_CampingChair_V1_F";
@@ -16797,7 +17369,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5386;
 									type="Land_CampingChair_V1_F";
@@ -16815,7 +17387,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5390;
 									type="Land_CampingChair_V1_F";
@@ -16832,7 +17404,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5391;
 									type="Land_CampingChair_V1_F";
@@ -16850,7 +17422,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5393;
 									type="Land_CampingChair_V1_F";
@@ -16868,7 +17440,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5395;
 									type="Land_CampingChair_V1_F";
@@ -16886,7 +17458,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5396;
 									type="Land_CampingChair_V1_F";
@@ -16904,7 +17476,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5401;
 									type="Land_CampingChair_V1_F";
@@ -16922,7 +17494,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5402;
 									type="Land_CampingChair_V1_F";
@@ -16940,7 +17512,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5405;
 									type="Land_CampingChair_V1_F";
@@ -16958,7 +17530,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5406;
 									type="Land_CampingChair_V1_F";
@@ -16976,7 +17548,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5407;
 									type="Land_CampingChair_V1_F";
@@ -16994,7 +17566,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5408;
 									type="Land_CampingChair_V1_F";
@@ -17012,7 +17584,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5411;
 									type="Land_CampingChair_V1_F";
@@ -17030,7 +17602,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5417;
 									type="Land_CampingChair_V1_F";
@@ -17048,7 +17620,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5418;
 									type="Land_CampingChair_V1_F";
@@ -17066,7 +17638,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5419;
 									type="Land_CampingChair_V1_F";
@@ -17084,7 +17656,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5421;
 									type="Land_CampingChair_V1_F";
@@ -17102,7 +17674,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5456;
 									type="Land_CampingChair_V1_F";
@@ -17120,7 +17692,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5457;
 									type="Land_CampingChair_V1_F";
@@ -17138,7 +17710,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5459;
 									type="Land_CampingChair_V1_F";
@@ -17156,7 +17728,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5460;
 									type="Land_CampingChair_V1_F";
@@ -17174,7 +17746,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5461;
 									type="Land_CampingChair_V1_F";
@@ -17192,7 +17764,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5464;
 									type="Land_CampingChair_V1_F";
@@ -17210,7 +17782,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5469;
 									type="Land_CampingChair_V1_F";
@@ -17227,7 +17799,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5470;
 									type="Land_CampingChair_V1_F";
@@ -17244,7 +17816,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5474;
 									type="Land_CampingChair_V1_F";
@@ -17262,7 +17834,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5475;
 									type="Land_CampingChair_V1_F";
@@ -17280,7 +17852,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5492;
 									type="Land_CampingChair_V1_F";
@@ -17298,7 +17870,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5493;
 									type="Land_CampingChair_V1_F";
@@ -17316,7 +17888,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5497;
 									type="Land_CampingChair_V1_F";
@@ -17334,7 +17906,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5564;
 									type="Land_CampingChair_V1_F";
@@ -17352,7 +17924,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5331;
 									type="Land_CampingChair_V1_folded_F";
@@ -17370,7 +17942,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5353;
 									type="Land_CampingChair_V1_folded_F";
@@ -17388,7 +17960,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5354;
 									type="Land_CampingChair_V1_folded_F";
@@ -17406,7 +17978,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5355;
 									type="Land_CampingChair_V1_folded_F";
@@ -17424,7 +17996,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5356;
 									type="Land_CampingChair_V1_folded_F";
@@ -17442,7 +18014,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5371;
 									type="Land_CampingChair_V1_folded_F";
@@ -17460,7 +18032,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5372;
 									type="Land_CampingChair_V1_folded_F";
@@ -17478,7 +18050,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5373;
 									type="Land_CampingChair_V1_folded_F";
@@ -17496,7 +18068,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5377;
 									type="Land_CampingChair_V1_folded_F";
@@ -17514,7 +18086,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5384;
 									type="Land_CampingChair_V1_folded_F";
@@ -17532,7 +18104,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5385;
 									type="Land_CampingChair_V1_folded_F";
@@ -17550,7 +18122,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5387;
 									type="Land_CampingChair_V1_folded_F";
@@ -17567,7 +18139,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5394;
 									type="Land_CampingChair_V1_folded_F";
@@ -17584,7 +18156,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5397;
 									type="Land_CampingChair_V1_folded_F";
@@ -17601,7 +18173,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5404;
 									type="Land_CampingChair_V1_folded_F";
@@ -17619,7 +18191,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5409;
 									type="Land_CampingChair_V1_folded_F";
@@ -17637,7 +18209,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5410;
 									type="Land_CampingChair_V1_folded_F";
@@ -17655,7 +18227,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5420;
 									type="Land_CampingChair_V1_folded_F";
@@ -17673,7 +18245,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5429;
 									type="Land_CampingChair_V1_folded_F";
@@ -17690,7 +18262,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5458;
 									type="Land_CampingChair_V1_folded_F";
@@ -17708,7 +18280,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5462;
 									type="Land_CampingChair_V1_folded_F";
@@ -17726,7 +18298,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5463;
 									type="Land_CampingChair_V1_folded_F";
@@ -17744,7 +18316,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5466;
 									type="Land_CampingChair_V1_folded_F";
@@ -17762,7 +18334,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5471;
 									type="Land_CampingChair_V1_folded_F";
@@ -17780,7 +18352,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5476;
 									type="Land_CampingChair_V1_folded_F";
@@ -17798,7 +18370,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5477;
 									type="Land_CampingChair_V1_folded_F";
@@ -17816,7 +18388,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5498;
 									type="Land_CampingChair_V1_folded_F";
@@ -17834,7 +18406,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5565;
 									type="Land_CampingChair_V1_folded_F";
@@ -17852,7 +18424,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5323;
 									type="Land_Wreck_UAZ_F";
@@ -17870,7 +18442,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5327;
 									type="Land_Wreck_UAZ_F";
@@ -17888,7 +18460,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5324;
 									type="Land_Wreck_Ural_F";
@@ -17906,7 +18478,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5325;
 									type="Land_Wreck_Ural_F";
@@ -17924,7 +18496,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5389;
 									type="Land_ToiletBox_F";
@@ -17942,7 +18514,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5424;
 									type="Land_ToiletBox_F";
@@ -17960,7 +18532,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5467;
 									type="Land_ToiletBox_F";
@@ -17978,7 +18550,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5473;
 									type="Land_ToiletBox_F";
@@ -17996,7 +18568,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5563;
 									type="Land_ToiletBox_F";
@@ -18014,7 +18586,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5571;
 									type="Land_RowBoat_V1_F";
@@ -18032,7 +18604,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5574;
 									type="Land_RowBoat_V1_F";
@@ -18050,7 +18622,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5577;
 									type="Land_RowBoat_V1_F";
@@ -18068,7 +18640,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5582;
 									type="Land_RowBoat_V1_F";
@@ -18086,7 +18658,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5583;
 									type="Land_RowBoat_V1_F";
@@ -18104,7 +18676,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5572;
 									type="Land_RowBoat_V2_F";
@@ -18122,7 +18694,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5576;
 									type="Land_RowBoat_V2_F";
@@ -18140,7 +18712,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5579;
 									type="Land_RowBoat_V2_F";
@@ -18158,7 +18730,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5584;
 									type="Land_RowBoat_V2_F";
@@ -18176,7 +18748,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5573;
 									type="Land_RowBoat_V3_F";
@@ -18194,7 +18766,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5575;
 									type="Land_RowBoat_V3_F";
@@ -18212,7 +18784,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5578;
 									type="Land_RowBoat_V3_F";
@@ -18230,7 +18802,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5581;
 									type="Land_RowBoat_V3_F";
@@ -18248,7 +18820,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5585;
 									type="Land_RowBoat_V3_F";
@@ -18580,7 +19152,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4312;
 									type="Land_Wreck_BMP2_F";
@@ -18597,7 +19169,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4313;
 									type="Land_Wreck_BRDM2_F";
@@ -18615,7 +19187,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4234;
 									type="Campfire_burning_F";
@@ -18632,7 +19204,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4235;
 									type="Campfire_burning_F";
@@ -18650,7 +19222,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4245;
 									type="Campfire_burning_F";
@@ -18667,7 +19239,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4246;
 									type="Campfire_burning_F";
@@ -18684,7 +19256,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4249;
 									type="Campfire_burning_F";
@@ -18702,7 +19274,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4256;
 									type="Land_ChairWood_F";
@@ -18714,13 +19286,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4559.5,15.402386,9408.5};
-										angles[]={-0,3.390136,0};
+										angles[]={0,3.390136,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4236;
 									type="FirePlace_burning_F";
@@ -18737,7 +19309,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4237;
 									type="FirePlace_burning_F";
@@ -18755,7 +19327,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4238;
 									type="FirePlace_burning_F";
@@ -18773,7 +19345,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4239;
 									type="FirePlace_burning_F";
@@ -18791,7 +19363,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4243;
 									type="FirePlace_burning_F";
@@ -18809,7 +19381,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4252;
 									type="FirePlace_burning_F";
@@ -18825,11 +19397,11 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4255;
 									type="FirePlace_burning_F";
-									atlOffset=0.25682068;
+									atlOffset=0.25681877;
 								};
 								class Item15
 								{
@@ -18843,7 +19415,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4311;
 									type="FirePlace_burning_F";
@@ -18861,7 +19433,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4257;
 									type="Land_CampingChair_V1_F";
@@ -18879,7 +19451,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4258;
 									type="Land_CampingChair_V1_F";
@@ -18897,7 +19469,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4261;
 									type="Land_CampingChair_V1_F";
@@ -18915,7 +19487,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4262;
 									type="Land_CampingChair_V1_F";
@@ -18933,7 +19505,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4263;
 									type="Land_CampingChair_V1_F";
@@ -18951,7 +19523,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4277;
 									type="Land_CampingChair_V1_F";
@@ -18969,7 +19541,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4278;
 									type="Land_CampingChair_V1_F";
@@ -18986,7 +19558,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4279;
 									type="Land_CampingChair_V1_F";
@@ -19003,7 +19575,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4287;
 									type="Land_CampingChair_V1_F";
@@ -19021,7 +19593,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4288;
 									type="Land_CampingChair_V1_F";
@@ -19039,7 +19611,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4289;
 									type="Land_CampingChair_V1_F";
@@ -19056,7 +19628,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4259;
 									type="Land_CampingChair_V1_folded_F";
@@ -19073,7 +19645,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4265;
 									type="Land_CampingChair_V1_folded_F";
@@ -19090,7 +19662,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4266;
 									type="Land_CampingChair_V1_folded_F";
@@ -19107,7 +19679,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4290;
 									type="Land_CampingChair_V1_folded_F";
@@ -19124,7 +19696,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4291;
 									type="Land_CampingChair_V1_folded_F";
@@ -19142,6 +19714,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
+										dynamicSimulation=1;
 									};
 									id=4314;
 									type="Land_LifeguardTower_01_F";
@@ -19158,6 +19731,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
+										dynamicSimulation=1;
 									};
 									id=4315;
 									type="Land_LifeguardTower_01_F";
@@ -19174,7 +19748,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4293;
 									type="Land_RowBoat_V1_F";
@@ -19192,7 +19766,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4296;
 									type="Land_RowBoat_V1_F";
@@ -19210,7 +19784,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4299;
 									type="Land_RowBoat_V1_F";
@@ -19228,7 +19802,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4294;
 									type="Land_RowBoat_V2_F";
@@ -19246,7 +19820,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4297;
 									type="Land_RowBoat_V2_F";
@@ -19264,7 +19838,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4301;
 									type="Land_RowBoat_V2_F";
@@ -19281,7 +19855,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4295;
 									type="Land_RowBoat_V3_F";
@@ -19299,7 +19873,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4298;
 									type="Land_RowBoat_V3_F";
@@ -19317,7 +19891,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4316;
 									type="Land_Wreck_UAZ_F";
@@ -19334,7 +19908,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4292;
 									type="Land_UWreck_FishingBoat_F";
@@ -19351,7 +19925,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4228;
 									type="Land_Sun_chair_F";
@@ -19368,7 +19942,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4229;
 									type="Land_Sun_chair_F";
@@ -19385,7 +19959,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4230;
 									type="Land_Sun_chair_F";
@@ -19402,7 +19976,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4231;
 									type="Land_Sun_chair_F";
@@ -19419,7 +19993,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4232;
 									type="Land_Sun_chair_F";
@@ -19437,7 +20011,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4233;
 									type="Land_Sun_chair_F";
@@ -19454,7 +20028,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4241;
 									type="Land_Sun_chair_F";
@@ -19471,7 +20045,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4242;
 									type="Land_Sun_chair_F";
@@ -19489,7 +20063,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4309;
 									type="Land_Sun_chair_F";
@@ -19507,7 +20081,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4310;
 									type="Land_Sun_chair_F";
@@ -19525,7 +20099,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4302;
 									type="Land_Sunshade_F";
@@ -19543,7 +20117,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4303;
 									type="Land_Sunshade_F";
@@ -19560,7 +20134,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4304;
 									type="Land_Sunshade_F";
@@ -19578,7 +20152,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4305;
 									type="Land_Sunshade_F";
@@ -19595,7 +20169,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4306;
 									type="Land_Sunshade_F";
@@ -19612,7 +20186,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4361;
 									type="FirePlace_burning_F";
@@ -19629,7 +20203,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4363;
 									type="FirePlace_burning_F";
@@ -19647,7 +20221,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4317;
 									type="Land_Bench_01_F";
@@ -19664,7 +20238,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4324;
 									type="Land_Bench_01_F";
@@ -19681,7 +20255,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4335;
 									type="Land_Bench_01_F";
@@ -19698,7 +20272,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4336;
 									type="Land_Bench_01_F";
@@ -19715,7 +20289,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4337;
 									type="Land_Bench_01_F";
@@ -19732,7 +20306,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4338;
 									type="Land_Bench_01_F";
@@ -19749,7 +20323,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4339;
 									type="Land_Bench_01_F";
@@ -19766,7 +20340,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4340;
 									type="Land_Bench_01_F";
@@ -19783,7 +20357,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4367;
 									type="Land_Bench_01_F";
@@ -19800,7 +20374,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4368;
 									type="Land_Bench_01_F";
@@ -19817,7 +20391,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4379;
 									type="Land_Wreck_BMP2_F";
@@ -19834,7 +20408,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4380;
 									type="Land_Wreck_BMP2_F";
@@ -19851,7 +20425,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4322;
 									type="Campfire_burning_F";
@@ -19868,7 +20442,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4325;
 									type="Land_ChairWood_F";
@@ -19885,7 +20459,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4326;
 									type="Land_ChairWood_F";
@@ -19903,7 +20477,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4358;
 									type="Land_ChairWood_F";
@@ -19921,7 +20495,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4359;
 									type="Land_ChairWood_F";
@@ -19939,7 +20513,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4362;
 									type="Land_ChairWood_F";
@@ -19957,7 +20531,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4364;
 									type="Land_ChairWood_F";
@@ -19975,7 +20549,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4373;
 									type="Land_ChairWood_F";
@@ -19993,7 +20567,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4372;
 									type="FirePlace_burning_F";
@@ -20010,7 +20584,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4318;
 									type="Land_CampingChair_V1_F";
@@ -20028,7 +20602,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4320;
 									type="Land_CampingChair_V1_F";
@@ -20045,7 +20619,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4330;
 									type="Land_CampingChair_V1_F";
@@ -20063,7 +20637,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4331;
 									type="Land_CampingChair_V1_F";
@@ -20080,7 +20654,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4332;
 									type="Land_CampingChair_V1_F";
@@ -20098,7 +20672,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4333;
 									type="Land_CampingChair_V1_F";
@@ -20116,7 +20690,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4341;
 									type="Land_CampingChair_V1_F";
@@ -20133,7 +20707,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4342;
 									type="Land_CampingChair_V1_F";
@@ -20151,7 +20725,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4345;
 									type="Land_CampingChair_V1_F";
@@ -20169,7 +20743,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4346;
 									type="Land_CampingChair_V1_F";
@@ -20187,7 +20761,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4348;
 									type="Land_CampingChair_V1_F";
@@ -20205,7 +20779,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4349;
 									type="Land_CampingChair_V1_F";
@@ -20223,7 +20797,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4350;
 									type="Land_CampingChair_V1_F";
@@ -20241,7 +20815,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4352;
 									type="Land_CampingChair_V1_F";
@@ -20259,7 +20833,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4354;
 									type="Land_CampingChair_V1_F";
@@ -20277,7 +20851,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4355;
 									type="Land_CampingChair_V1_F";
@@ -20295,7 +20869,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4356;
 									type="Land_CampingChair_V1_F";
@@ -20313,7 +20887,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4321;
 									type="Land_CampingChair_V1_folded_F";
@@ -20330,7 +20904,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4323;
 									type="Land_CampingChair_V1_folded_F";
@@ -20347,7 +20921,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4334;
 									type="Land_CampingChair_V1_folded_F";
@@ -20365,7 +20939,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4343;
 									type="Land_CampingChair_V1_folded_F";
@@ -20383,7 +20957,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4344;
 									type="Land_CampingChair_V1_folded_F";
@@ -20401,7 +20975,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4347;
 									type="Land_CampingChair_V1_folded_F";
@@ -20419,7 +20993,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4351;
 									type="Land_CampingChair_V1_folded_F";
@@ -20437,7 +21011,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4353;
 									type="Land_CampingChair_V1_folded_F";
@@ -20454,7 +21028,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4357;
 									type="Land_CampingChair_V1_folded_F";
@@ -20472,7 +21046,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4382;
 									type="Campfire_burning_F";
@@ -20490,7 +21064,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4383;
 									type="Campfire_burning_F";
@@ -20508,7 +21082,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4384;
 									type="Campfire_burning_F";
@@ -20526,7 +21100,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4385;
 									type="Campfire_burning_F";
@@ -20544,7 +21118,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4386;
 									type="Campfire_burning_F";
@@ -20561,10 +21135,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4417;
 									type="FirePlace_burning_F";
+									atlOffset=0.00037312508;
 								};
 								class Item114
 								{
@@ -20578,7 +21153,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4420;
 									type="FirePlace_burning_F";
@@ -20596,7 +21171,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4422;
 									type="FirePlace_burning_F";
@@ -20614,7 +21189,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4402;
 									type="Land_CampingChair_V1_F";
@@ -20632,7 +21207,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4403;
 									type="Land_CampingChair_V1_F";
@@ -20650,7 +21225,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4406;
 									type="Land_CampingChair_V1_F";
@@ -20668,10 +21243,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4412;
 									type="Land_CampingChair_V1_F";
+									atlOffset=-0.00013017654;
 								};
 								class Item120
 								{
@@ -20685,7 +21261,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4407;
 									type="Land_CampingChair_V1_folded_F";
@@ -20703,7 +21279,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4413;
 									type="Land_CampingChair_V1_folded_F";
@@ -20720,7 +21296,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4393;
 									type="Land_Sunshade_03_F";
@@ -20738,7 +21314,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4398;
 									type="Land_Sunshade_03_F";
@@ -20755,7 +21331,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4395;
 									type="Land_Sunshade_02_F";
@@ -20772,7 +21348,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4429;
 									type="Land_BeachBooth_01_F";
@@ -20790,7 +21366,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4427;
 									type="Land_BeachBooth_01_F";
@@ -20808,7 +21384,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4436;
 									type="Land_BeachBooth_01_F";
@@ -20825,7 +21401,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4438;
 									type="Land_BeachBooth_01_F";
@@ -20842,7 +21418,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4447;
 									type="Land_Bench_01_F";
@@ -20859,7 +21435,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4448;
 									type="Land_Bench_01_F";
@@ -20876,7 +21452,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4451;
 									type="Land_Bench_01_F";
@@ -20893,7 +21469,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4452;
 									type="Land_Bench_01_F";
@@ -20910,7 +21486,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4453;
 									type="Land_Bench_01_F";
@@ -20927,7 +21503,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4454;
 									type="Land_Bench_01_F";
@@ -20944,7 +21520,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4455;
 									type="Land_Bench_01_F";
@@ -20961,7 +21537,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4479;
 									type="Land_Bench_01_F";
@@ -20978,7 +21554,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4481;
 									type="Land_Bench_01_F";
@@ -20995,7 +21571,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4497;
 									type="Land_Bench_01_F";
@@ -21012,7 +21588,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4424;
 									type="Campfire_burning_F";
@@ -21030,7 +21606,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4443;
 									type="Campfire_burning_F";
@@ -21048,7 +21624,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4444;
 									type="Campfire_burning_F";
@@ -21065,7 +21641,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4460;
 									type="Land_ChairWood_F";
@@ -21083,7 +21659,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4463;
 									type="Land_ChairWood_F";
@@ -21101,7 +21677,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4466;
 									type="Land_ChairWood_F";
@@ -21119,7 +21695,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4467;
 									type="Land_ChairWood_F";
@@ -21136,7 +21712,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4468;
 									type="Land_ChairWood_F";
@@ -21153,7 +21729,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4469;
 									type="Land_ChairWood_F";
@@ -21170,7 +21746,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4470;
 									type="Land_ChairWood_F";
@@ -21188,7 +21764,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4471;
 									type="Land_ChairWood_F";
@@ -21206,7 +21782,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4472;
 									type="Land_ChairWood_F";
@@ -21223,7 +21799,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4473;
 									type="Land_ChairWood_F";
@@ -21240,7 +21816,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4474;
 									type="Land_ChairWood_F";
@@ -21257,7 +21833,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4475;
 									type="Land_ChairWood_F";
@@ -21275,7 +21851,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4476;
 									type="Land_ChairWood_F";
@@ -21292,7 +21868,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4482;
 									type="Land_ChairWood_F";
@@ -21310,7 +21886,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4483;
 									type="Land_ChairWood_F";
@@ -21322,16 +21898,17 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4499.5063,15.353436,9462.4492};
-										angles[]={-0,1.0331024,0};
+										angles[]={0,1.0331024,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4486;
 									type="Land_ChairWood_F";
+									atlOffset=9.5367432e-007;
 								};
 								class Item158
 								{
@@ -21345,7 +21922,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4492;
 									type="Land_ChairWood_F";
@@ -21363,7 +21940,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4493;
 									type="Land_ChairWood_F";
@@ -21381,7 +21958,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4494;
 									type="Land_ChairWood_F";
@@ -21399,7 +21976,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4495;
 									type="Land_ChairWood_F";
@@ -21417,7 +21994,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4498;
 									type="Land_ChairWood_F";
@@ -21435,7 +22012,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4500;
 									type="Land_ChairWood_F";
@@ -21453,7 +22030,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4501;
 									type="Land_ChairWood_F";
@@ -21470,7 +22047,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4503;
 									type="Land_ChairWood_F";
@@ -21488,7 +22065,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4461;
 									type="FirePlace_burning_F";
@@ -21505,7 +22082,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4462;
 									type="FirePlace_burning_F";
@@ -21522,7 +22099,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4484;
 									type="FirePlace_burning_F";
@@ -21533,13 +22110,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4499,15.402386,9460.5};
-										angles[]={-0,1.2870282,0};
+										angles[]={0,1.2870282,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4485;
 									type="FirePlace_burning_F";
@@ -21556,7 +22133,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4490;
 									type="FirePlace_burning_F";
@@ -21572,7 +22149,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4496;
 									type="FirePlace_burning_F";
@@ -21588,7 +22165,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4499;
 									type="FirePlace_burning_F";
@@ -21605,7 +22182,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4502;
 									type="FirePlace_burning_F";
@@ -21622,7 +22199,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4504;
 									type="FirePlace_burning_F";
@@ -21640,7 +22217,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4439;
 									type="Land_CampingChair_V1_F";
@@ -21658,7 +22235,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4440;
 									type="Land_CampingChair_V1_F";
@@ -21676,7 +22253,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4441;
 									type="Land_CampingChair_V1_F";
@@ -21694,7 +22271,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4442;
 									type="Land_CampingChair_V1_F";
@@ -21712,7 +22289,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4445;
 									type="Land_CampingChair_V1_folded_F";
@@ -21730,7 +22307,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4446;
 									type="Land_CampingChair_V1_folded_F";
@@ -21748,7 +22325,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4505;
 									type="Land_ChairWood_F";
@@ -21766,7 +22343,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4506;
 									type="Land_ChairWood_F";
@@ -21784,7 +22361,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4507;
 									type="Land_ChairWood_F";
@@ -21801,7 +22378,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4510;
 									type="Land_ChairWood_F";
@@ -21819,7 +22396,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4511;
 									type="Land_ChairWood_F";
@@ -21837,7 +22414,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4512;
 									type="Land_ChairWood_F";
@@ -21855,7 +22432,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4514;
 									type="Land_ChairWood_F";
@@ -21872,7 +22449,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4508;
 									type="FirePlace_burning_F";
@@ -21889,7 +22466,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4509;
 									type="FirePlace_burning_F";
@@ -21906,7 +22483,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4513;
 									type="FirePlace_burning_F";
@@ -21923,7 +22500,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4517;
 									type="Land_ToiletBox_F";
@@ -21941,7 +22518,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4519;
 									type="Land_ToiletBox_F";
@@ -21959,7 +22536,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4520;
 									type="Land_ToiletBox_F";
@@ -21977,7 +22554,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4521;
 									type="Land_ToiletBox_F";
@@ -21995,7 +22572,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4523;
 									type="Land_ToiletBox_F";
@@ -22012,7 +22589,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4524;
 									type="Land_ChairWood_F";
@@ -22030,7 +22607,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4525;
 									type="FirePlace_burning_F";
@@ -22047,7 +22624,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4534;
 									type="Land_ChairWood_F";
@@ -22059,20 +22636,20 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4512,15.402386,9557};
-										angles[]={-0,4.9992557,0};
+										angles[]={0,4.9992557,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4535;
 									type="FirePlace_burning_F";
 								};
 							};
 							id=1789;
-							atlOffset=0.00034713745;
+							atlOffset=-0.020704269;
 						};
 						class Item3
 						{
@@ -22137,7 +22714,7 @@ class Mission
 						};
 					};
 					id=60;
-					atlOffset=-1.9275932;
+					atlOffset=-1.9328556;
 				};
 				class Item2
 				{
@@ -22242,7 +22819,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4548;
 									type="Land_Bench_01_F";
@@ -22260,7 +22837,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4549;
 									type="Land_Bench_01_F";
@@ -22278,7 +22855,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4573;
 									type="Land_Bench_01_F";
@@ -22295,7 +22872,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4575;
 									type="Land_Bench_01_F";
@@ -22312,7 +22889,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4550;
 									type="Campfire_burning_F";
@@ -22330,7 +22907,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4558;
 									type="Campfire_burning_F";
@@ -22347,7 +22924,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4576;
 									type="Campfire_burning_F";
@@ -22364,7 +22941,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4601;
 									type="Campfire_burning_F";
@@ -22382,7 +22959,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4536;
 									type="Land_ChairWood_F";
@@ -22400,7 +22977,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4544;
 									type="Land_ChairWood_F";
@@ -22417,7 +22994,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4546;
 									type="Land_ChairWood_F";
@@ -22434,7 +23011,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4547;
 									type="Land_ChairWood_F";
@@ -22452,7 +23029,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4572;
 									type="Land_ChairWood_F";
@@ -22470,7 +23047,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4595;
 									type="Land_ChairWood_F";
@@ -22482,13 +23059,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4948.5063,30.215605,9064.9492};
-										angles[]={0,0.06054236,-0};
+										angles[]={0,0.06054236,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4596;
 									type="Land_ChairWood_F";
@@ -22506,7 +23083,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4583;
 									type="FirePlace_burning_F";
@@ -22522,7 +23099,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4597;
 									type="FirePlace_burning_F";
@@ -22539,7 +23116,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4551;
 									type="Land_CampingChair_V1_F";
@@ -22557,7 +23134,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4552;
 									type="Land_CampingChair_V1_F";
@@ -22575,7 +23152,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4553;
 									type="Land_CampingChair_V1_F";
@@ -22593,7 +23170,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4557;
 									type="Land_CampingChair_V1_F";
@@ -22611,7 +23188,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4559;
 									type="Land_CampingChair_V1_F";
@@ -22629,7 +23206,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4560;
 									type="Land_CampingChair_V1_F";
@@ -22647,7 +23224,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4561;
 									type="Land_CampingChair_V1_F";
@@ -22665,7 +23242,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4562;
 									type="Land_CampingChair_V1_F";
@@ -22683,7 +23260,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4577;
 									type="Land_CampingChair_V1_F";
@@ -22700,7 +23277,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4578;
 									type="Land_CampingChair_V1_F";
@@ -22717,7 +23294,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4599;
 									type="Land_CampingChair_V1_F";
@@ -22735,7 +23312,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4600;
 									type="Land_CampingChair_V1_F";
@@ -22753,7 +23330,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4554;
 									type="Land_CampingChair_V1_folded_F";
@@ -22771,7 +23348,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4555;
 									type="Land_CampingChair_V1_folded_F";
@@ -22789,7 +23366,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4563;
 									type="Land_CampingChair_V1_folded_F";
@@ -22807,7 +23384,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4564;
 									type="Land_CampingChair_V1_folded_F";
@@ -22825,7 +23402,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4579;
 									type="Land_CampingChair_V1_folded_F";
@@ -22842,7 +23419,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4580;
 									type="Land_CampingChair_V1_folded_F";
@@ -22859,7 +23436,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4603;
 									type="Land_CampingChair_V1_folded_F";
@@ -22877,7 +23454,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4598;
 									type="Land_Wreck_Ural_F";
@@ -22895,7 +23472,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4593;
 									type="Land_ToiletBox_F";
@@ -22913,7 +23490,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4594;
 									type="Land_ToiletBox_F";
@@ -22931,7 +23508,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5061;
 									type="Land_Wreck_BRDM2_F";
@@ -22949,7 +23526,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5067;
 									type="Campfire_burning_F";
@@ -22967,7 +23544,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5064;
 									type="Land_CampingChair_V1_F";
@@ -22985,7 +23562,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5065;
 									type="Land_CampingChair_V1_F";
@@ -23003,7 +23580,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5066;
 									type="Land_CampingChair_V1_folded_F";
@@ -23021,14 +23598,14 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9987;
 									type="FirePlace_burning_F";
 								};
 							};
 							id=1796;
-							atlOffset=0.42668724;
+							atlOffset=0.42674637;
 						};
 						class Item2
 						{
@@ -23075,7 +23652,7 @@ class Mission
 						};
 					};
 					id=61;
-					atlOffset=0.091636658;
+					atlOffset=0.091651917;
 				};
 				class Item3
 				{
@@ -23180,7 +23757,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3419;
 									type="Land_Bench_01_F";
@@ -23197,7 +23774,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3446;
 									type="Land_Bench_01_F";
@@ -23214,7 +23791,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3417;
 									type="Land_ChairWood_F";
@@ -23231,7 +23808,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3426;
 									type="Land_ChairWood_F";
@@ -23248,7 +23825,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3442;
 									type="Land_ChairWood_F";
@@ -23266,7 +23843,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3467;
 									type="Land_ChairWood_F";
@@ -23283,7 +23860,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3468;
 									type="Land_ChairWood_F";
@@ -23301,7 +23878,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3469;
 									type="Land_ChairWood_F";
@@ -23318,7 +23895,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3470;
 									type="Land_ChairWood_F";
@@ -23335,7 +23912,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3471;
 									type="Land_ChairWood_F";
@@ -23352,7 +23929,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3472;
 									type="Land_ChairWood_F";
@@ -23370,7 +23947,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3473;
 									type="Land_ChairWood_F";
@@ -23388,7 +23965,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3418;
 									type="FirePlace_burning_F";
@@ -23405,7 +23982,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3427;
 									type="FirePlace_burning_F";
@@ -23422,7 +23999,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3443;
 									type="FirePlace_burning_F";
@@ -23439,7 +24016,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3464;
 									type="FirePlace_burning_F";
@@ -23456,7 +24033,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3465;
 									type="FirePlace_burning_F";
@@ -23473,7 +24050,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3493;
 									type="Land_Bench_01_F";
@@ -23490,7 +24067,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3498;
 									type="Land_Bench_01_F";
@@ -23507,7 +24084,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3499;
 									type="Land_Bench_01_F";
@@ -23524,7 +24101,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3495;
 									type="Campfire_burning_F";
@@ -23542,7 +24119,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3500;
 									type="Campfire_burning_F";
@@ -23560,7 +24137,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3482;
 									type="Land_ChairWood_F";
@@ -23577,7 +24154,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3483;
 									type="Land_ChairWood_F";
@@ -23594,7 +24171,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3487;
 									type="Land_ChairWood_F";
@@ -23612,7 +24189,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3488;
 									type="Land_ChairWood_F";
@@ -23630,7 +24207,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3489;
 									type="Land_ChairWood_F";
@@ -23647,7 +24224,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3491;
 									type="Land_ChairWood_F";
@@ -23665,7 +24242,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3501;
 									type="Land_ChairWood_F";
@@ -23682,7 +24259,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3484;
 									type="FirePlace_burning_F";
@@ -23699,7 +24276,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3486;
 									type="FirePlace_burning_F";
@@ -23717,7 +24294,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3490;
 									type="FirePlace_burning_F";
@@ -23734,7 +24311,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3505;
 									type="Land_RowBoat_V1_F";
@@ -23752,7 +24329,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3504;
 									type="Land_RowBoat_V2_F";
@@ -23770,7 +24347,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3506;
 									type="Land_RowBoat_V2_F";
@@ -23788,7 +24365,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3502;
 									type="Land_RowBoat_V3_F";
@@ -23806,7 +24383,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3492;
 									type="Land_ToiletBox_F";
@@ -23823,7 +24400,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3496;
 									type="Land_ToiletBox_F";
@@ -23840,7 +24417,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3497;
 									type="Land_ToiletBox_F";
@@ -24000,7 +24577,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3188;
 									type="Land_ChairWood_F";
@@ -24017,7 +24594,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3256;
 									type="Land_ChairWood_F";
@@ -24035,7 +24612,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3257;
 									type="Land_ChairWood_F";
@@ -24053,7 +24630,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3258;
 									type="Land_ChairWood_F";
@@ -24070,7 +24647,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3267;
 									type="Land_ChairWood_F";
@@ -24087,7 +24664,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3259;
 									type="FirePlace_burning_F";
@@ -24105,7 +24682,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3260;
 									type="FirePlace_burning_F";
@@ -24122,7 +24699,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3261;
 									type="FirePlace_burning_F";
@@ -24139,7 +24716,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3314;
 									type="Land_Bench_01_F";
@@ -24156,10 +24733,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3319;
 									type="Campfire_burning_F";
+									atlOffset=0.00032043457;
 								};
 								class Item10
 								{
@@ -24173,7 +24751,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3284;
 									type="Land_ChairWood_F";
@@ -24190,7 +24768,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3288;
 									type="Land_ChairWood_F";
@@ -24207,7 +24785,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3289;
 									type="Land_ChairWood_F";
@@ -24224,7 +24802,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3305;
 									type="Land_ChairWood_F";
@@ -24242,7 +24820,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3306;
 									type="Land_ChairWood_F";
@@ -24259,7 +24837,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3307;
 									type="Land_ChairWood_F";
@@ -24277,7 +24855,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3309;
 									type="Land_ChairWood_F";
@@ -24295,7 +24873,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3310;
 									type="Land_ChairWood_F";
@@ -24312,7 +24890,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3312;
 									type="Land_ChairWood_F";
@@ -24329,7 +24907,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3316;
 									type="Land_ChairWood_F";
@@ -24347,7 +24925,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3317;
 									type="Land_ChairWood_F";
@@ -24365,7 +24943,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3318;
 									type="Land_ChairWood_F";
@@ -24382,7 +24960,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3308;
 									type="FirePlace_burning_F";
@@ -24399,7 +24977,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3311;
 									type="FirePlace_burning_F";
@@ -24416,10 +24994,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3340;
 									type="Campfire_burning_F";
+									atlOffset=-0.00038146973;
 								};
 								class Item25
 								{
@@ -24433,10 +25012,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3341;
 									type="Land_CampingChair_V1_F";
+									atlOffset=-3.0517578e-005;
 								};
 								class Item26
 								{
@@ -24450,10 +25030,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3342;
 									type="Land_CampingChair_V1_F";
+									atlOffset=-7.6293945e-005;
 								};
 								class Item27
 								{
@@ -24467,10 +25048,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3343;
 									type="Land_CampingChair_V1_F";
+									atlOffset=-0.00016784668;
 								};
 								class Item28
 								{
@@ -24484,10 +25066,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3344;
 									type="Land_CampingChair_V1_F";
+									atlOffset=-0.0039367676;
 								};
 								class Item29
 								{
@@ -24501,7 +25084,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3345;
 									type="Land_CampingChair_V1_folded_F";
@@ -24518,7 +25101,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3346;
 									type="Land_CampingChair_V1_folded_F";
@@ -24535,10 +25118,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3347;
 									type="Land_CampingChair_V1_F";
+									atlOffset=-0.0001373291;
 								};
 								class Item32
 								{
@@ -24552,7 +25136,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3337;
 									type="Land_ToiletBox_F";
@@ -24569,7 +25153,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3338;
 									type="Land_ToiletBox_F";
@@ -24587,7 +25171,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3351;
 									type="Land_ToiletBox_F";
@@ -24605,7 +25189,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3355;
 									type="Campfire_burning_F";
@@ -24623,7 +25207,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3353;
 									type="Land_CampingChair_V1_F";
@@ -24640,14 +25224,14 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3354;
 									type="Land_CampingChair_V1_F";
 								};
 							};
 							id=1781;
-							atlOffset=0.010025024;
+							atlOffset=0.010009766;
 						};
 						class Item2
 						{
@@ -24694,7 +25278,7 @@ class Mission
 						};
 					};
 					id=63;
-					atlOffset=-0.13925171;
+					atlOffset=-0.13926697;
 				};
 				class Item5
 				{
@@ -24970,7 +25554,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3553;
 									type="Land_BeachBooth_01_F";
@@ -24987,7 +25571,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3554;
 									type="Land_BeachBooth_01_F";
@@ -25004,7 +25588,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3517;
 									type="FirePlace_burning_F";
@@ -25022,7 +25606,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3518;
 									type="FirePlace_burning_F";
@@ -25040,7 +25624,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3519;
 									type="FirePlace_burning_F";
@@ -25058,7 +25642,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3520;
 									type="FirePlace_burning_F";
@@ -25076,6 +25660,7 @@ class Mission
 									flags=1;
 									class Attributes
 									{
+										dynamicSimulation=1;
 									};
 									id=3555;
 									type="Land_LifeguardTower_01_F";
@@ -25093,6 +25678,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
+										dynamicSimulation=1;
 									};
 									id=3556;
 									type="Land_LifeguardTower_01_F";
@@ -25109,7 +25695,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3507;
 									type="Land_Sun_chair_F";
@@ -25126,7 +25712,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3508;
 									type="Land_Sun_chair_F";
@@ -25143,7 +25729,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3509;
 									type="Land_Sun_chair_F";
@@ -25160,7 +25746,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3510;
 									type="Land_Sun_chair_F";
@@ -25177,10 +25763,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3511;
 									type="Land_Sun_chair_F";
+									atlOffset=-2.3841858e-007;
 								};
 								class Item13
 								{
@@ -25194,7 +25781,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3512;
 									type="Land_Sun_chair_F";
@@ -25211,7 +25798,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3513;
 									type="Land_Sun_chair_F";
@@ -25228,7 +25815,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3514;
 									type="Land_Sun_chair_F";
@@ -25245,10 +25832,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3526;
 									type="Land_Sunshade_F";
+									atlOffset=4.7683716e-007;
 								};
 								class Item17
 								{
@@ -25262,10 +25850,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3530;
 									type="Land_Sunshade_F";
+									atlOffset=4.7683716e-007;
 								};
 								class Item18
 								{
@@ -25279,7 +25868,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3531;
 									type="Land_Sunshade_F";
@@ -25297,7 +25886,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3533;
 									type="Land_Sunshade_F";
@@ -25315,7 +25904,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3538;
 									type="Land_Sunshade_01_F";
@@ -25333,7 +25922,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3543;
 									type="Land_Sunshade_01_F";
@@ -25351,7 +25940,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3548;
 									type="Land_Sunshade_01_F";
@@ -25368,7 +25957,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3536;
 									type="Land_Sunshade_03_F";
@@ -25385,7 +25974,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3541;
 									type="Land_Sunshade_03_F";
@@ -25403,10 +25992,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3546;
 									type="Land_Sunshade_03_F";
+									atlOffset=-2.3841858e-007;
 								};
 								class Item26
 								{
@@ -25420,7 +26010,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3523;
 									type="Land_Wreck_Traw2_F";
@@ -25437,7 +26027,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3524;
 									type="Land_Wreck_Traw_F";
@@ -25454,7 +26044,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3773;
 									type="Land_BeachBooth_01_F";
@@ -25471,7 +26061,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3774;
 									type="Land_BeachBooth_01_F";
@@ -25488,7 +26078,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3638;
 									type="Land_Bench_01_F";
@@ -25505,7 +26095,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3741;
 									type="Land_Bench_01_F";
@@ -25522,7 +26112,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3745;
 									type="Land_Bench_01_F";
@@ -25539,7 +26129,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3786;
 									type="Land_Bench_01_F";
@@ -25556,7 +26146,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3803;
 									type="Land_Bench_01_F";
@@ -25573,7 +26163,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3812;
 									type="Land_Bench_01_F";
@@ -25590,7 +26180,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3819;
 									type="Land_Bench_01_F";
@@ -25607,7 +26197,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3820;
 									type="Land_Bench_01_F";
@@ -25624,7 +26214,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3831;
 									type="Land_Bench_01_F";
@@ -25641,7 +26231,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3832;
 									type="Land_Bench_01_F";
@@ -25658,7 +26248,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3850;
 									type="Land_Bench_01_F";
@@ -25675,7 +26265,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3859;
 									type="Land_Bench_01_F";
@@ -25692,7 +26282,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3860;
 									type="Land_Bench_01_F";
@@ -25709,7 +26299,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3861;
 									type="Land_Bench_01_F";
@@ -25726,7 +26316,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3862;
 									type="Land_Bench_01_F";
@@ -25743,7 +26333,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3871;
 									type="Land_Bench_01_F";
@@ -25760,7 +26350,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3887;
 									type="Land_Bench_01_F";
@@ -25777,7 +26367,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3888;
 									type="Land_Bench_01_F";
@@ -25794,7 +26384,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3889;
 									type="Land_Bench_01_F";
@@ -25811,7 +26401,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3893;
 									type="Land_Bench_01_F";
@@ -25828,7 +26418,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3894;
 									type="Land_Bench_01_F";
@@ -25845,7 +26435,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3897;
 									type="Land_Bench_01_F";
@@ -25862,7 +26452,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3899;
 									type="Land_Bench_01_F";
@@ -25879,7 +26469,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3904;
 									type="Land_Bench_01_F";
@@ -25896,7 +26486,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3905;
 									type="Land_Bench_01_F";
@@ -25913,7 +26503,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3908;
 									type="Land_Bench_01_F";
@@ -25930,7 +26520,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3909;
 									type="Land_Bench_01_F";
@@ -25947,7 +26537,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3557;
 									type="Land_Wreck_BMP2_F";
@@ -25964,7 +26554,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3568;
 									type="Campfire_burning_F";
@@ -25981,7 +26571,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3572;
 									type="Campfire_burning_F";
@@ -25999,7 +26589,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3586;
 									type="Campfire_burning_F";
@@ -26017,7 +26607,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3600;
 									type="Campfire_burning_F";
@@ -26035,7 +26625,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3636;
 									type="Campfire_burning_F";
@@ -26052,7 +26642,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3641;
 									type="Campfire_burning_F";
@@ -26069,7 +26659,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3742;
 									type="Campfire_burning_F";
@@ -26085,7 +26675,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3747;
 									type="Campfire_burning_F";
@@ -26102,7 +26692,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3778;
 									type="Campfire_burning_F";
@@ -26119,7 +26709,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3813;
 									type="Campfire_burning_F";
@@ -26136,7 +26726,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3814;
 									type="Campfire_burning_F";
@@ -26154,7 +26744,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3818;
 									type="Campfire_burning_F";
@@ -26171,7 +26761,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3851;
 									type="Campfire_burning_F";
@@ -26188,7 +26778,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3872;
 									type="Campfire_burning_F";
@@ -26206,7 +26796,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3634;
 									type="Land_ChairWood_F";
@@ -26223,7 +26813,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3635;
 									type="Land_ChairWood_F";
@@ -26241,7 +26831,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3654;
 									type="Land_ChairWood_F";
@@ -26258,7 +26848,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3655;
 									type="Land_ChairWood_F";
@@ -26275,7 +26865,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3657;
 									type="Land_ChairWood_F";
@@ -26292,7 +26882,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3658;
 									type="Land_ChairWood_F";
@@ -26309,7 +26899,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3660;
 									type="Land_ChairWood_F";
@@ -26326,7 +26916,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3661;
 									type="Land_ChairWood_F";
@@ -26343,7 +26933,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3662;
 									type="Land_ChairWood_F";
@@ -26360,7 +26950,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3663;
 									type="Land_ChairWood_F";
@@ -26378,7 +26968,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3664;
 									type="Land_ChairWood_F";
@@ -26396,7 +26986,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3665;
 									type="Land_ChairWood_F";
@@ -26414,7 +27004,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3666;
 									type="Land_ChairWood_F";
@@ -26432,7 +27022,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3668;
 									type="Land_ChairWood_F";
@@ -26449,7 +27039,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3718;
 									type="Land_ChairWood_F";
@@ -26465,7 +27055,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3719;
 									type="Land_ChairWood_F";
@@ -26483,7 +27073,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3720;
 									type="Land_ChairWood_F";
@@ -26499,7 +27089,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3721;
 									type="Land_ChairWood_F";
@@ -26516,7 +27106,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3722;
 									type="Land_ChairWood_F";
@@ -26533,7 +27123,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3723;
 									type="Land_ChairWood_F";
@@ -26551,7 +27141,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3725;
 									type="Land_ChairWood_F";
@@ -26569,7 +27159,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3727;
 									type="Land_ChairWood_F";
@@ -26586,7 +27176,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3728;
 									type="Land_ChairWood_F";
@@ -26603,7 +27193,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3729;
 									type="Land_ChairWood_F";
@@ -26620,7 +27210,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3730;
 									type="Land_ChairWood_F";
@@ -26637,7 +27227,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3731;
 									type="Land_ChairWood_F";
@@ -26655,7 +27245,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3732;
 									type="Land_ChairWood_F";
@@ -26673,7 +27263,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3733;
 									type="Land_ChairWood_F";
@@ -26690,7 +27280,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3734;
 									type="Land_ChairWood_F";
@@ -26707,7 +27297,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3736;
 									type="Land_ChairWood_F";
@@ -26724,7 +27314,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3739;
 									type="Land_ChairWood_F";
@@ -26741,7 +27331,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3740;
 									type="Land_ChairWood_F";
@@ -26758,7 +27348,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3759;
 									type="Land_ChairWood_F";
@@ -26775,7 +27365,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3760;
 									type="Land_ChairWood_F";
@@ -26792,7 +27382,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3768;
 									type="Land_ChairWood_F";
@@ -26809,7 +27399,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3769;
 									type="Land_ChairWood_F";
@@ -26826,7 +27416,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3783;
 									type="Land_ChairWood_F";
@@ -26843,7 +27433,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3784;
 									type="Land_ChairWood_F";
@@ -26860,7 +27450,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3799;
 									type="Land_ChairWood_F";
@@ -26878,7 +27468,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3801;
 									type="Land_ChairWood_F";
@@ -26896,7 +27486,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3821;
 									type="Land_ChairWood_F";
@@ -26913,7 +27503,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3822;
 									type="Land_ChairWood_F";
@@ -26930,7 +27520,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3833;
 									type="Land_ChairWood_F";
@@ -26948,7 +27538,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3834;
 									type="Land_ChairWood_F";
@@ -26965,7 +27555,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3839;
 									type="Land_ChairWood_F";
@@ -26982,7 +27572,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3847;
 									type="Land_ChairWood_F";
@@ -26999,7 +27589,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3848;
 									type="Land_ChairWood_F";
@@ -27017,7 +27607,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3886;
 									type="Land_ChairWood_F";
@@ -27034,7 +27624,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3890;
 									type="Land_ChairWood_F";
@@ -27051,7 +27641,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3892;
 									type="Land_ChairWood_F";
@@ -27069,7 +27659,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3656;
 									type="FirePlace_burning_F";
@@ -27087,7 +27677,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3659;
 									type="FirePlace_burning_F";
@@ -27104,7 +27694,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3735;
 									type="FirePlace_burning_F";
@@ -27121,7 +27711,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3737;
 									type="FirePlace_burning_F";
@@ -27137,7 +27727,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3738;
 									type="FirePlace_burning_F";
@@ -27153,7 +27743,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3761;
 									type="FirePlace_burning_F";
@@ -27170,7 +27760,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3770;
 									type="FirePlace_burning_F";
@@ -27186,7 +27776,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3785;
 									type="FirePlace_burning_F";
@@ -27203,7 +27793,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3800;
 									type="FirePlace_burning_F";
@@ -27220,7 +27810,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3835;
 									type="FirePlace_burning_F";
@@ -27237,7 +27827,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3840;
 									type="FirePlace_burning_F";
@@ -27253,7 +27843,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3846;
 									type="FirePlace_burning_F";
@@ -27270,7 +27860,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3891;
 									type="FirePlace_burning_F";
@@ -27287,7 +27877,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3567;
 									type="Land_CampingChair_V1_F";
@@ -27304,7 +27894,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3570;
 									type="Land_CampingChair_V1_F";
@@ -27322,7 +27912,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3571;
 									type="Land_CampingChair_V1_F";
@@ -27340,7 +27930,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3573;
 									type="Land_CampingChair_V1_F";
@@ -27358,7 +27948,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3583;
 									type="Land_CampingChair_V1_F";
@@ -27376,7 +27966,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3584;
 									type="Land_CampingChair_V1_F";
@@ -27394,7 +27984,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3585;
 									type="Land_CampingChair_V1_F";
@@ -27412,10 +28002,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3589;
 									type="Land_CampingChair_V1_F";
+									atlOffset=-1.0967255e-005;
 								};
 								class Item143
 								{
@@ -27429,11 +28020,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3592;
 									type="Land_CampingChair_V1_F";
-									atlOffset=2.3841858e-005;
+									atlOffset=2.4080276e-005;
 								};
 								class Item144
 								{
@@ -27447,7 +28038,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3593;
 									type="Land_CampingChair_V1_F";
@@ -27465,7 +28056,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3598;
 									type="Land_CampingChair_V1_F";
@@ -27482,7 +28073,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3599;
 									type="Land_CampingChair_V1_F";
@@ -27499,7 +28090,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3604;
 									type="Land_CampingChair_V1_F";
@@ -27516,7 +28107,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3605;
 									type="Land_CampingChair_V1_F";
@@ -27533,7 +28124,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3610;
 									type="Land_CampingChair_V1_F";
@@ -27550,7 +28141,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3615;
 									type="Land_CampingChair_V1_F";
@@ -27568,7 +28159,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3621;
 									type="Land_CampingChair_V1_F";
@@ -27586,7 +28177,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3625;
 									type="Land_CampingChair_V1_F";
@@ -27604,7 +28195,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3642;
 									type="Land_CampingChair_V1_F";
@@ -27622,7 +28213,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3643;
 									type="Land_CampingChair_V1_F";
@@ -27640,7 +28231,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3652;
 									type="Land_CampingChair_V1_F";
@@ -27651,13 +28242,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={1153.4729,66.59745,5962.916};
-										angles[]={-0,5.1175356,0};
+										angles[]={0,5.1175356,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3775;
 									type="Land_CampingChair_V1_F";
@@ -27675,7 +28266,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3777;
 									type="Land_CampingChair_V1_F";
@@ -27692,7 +28283,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3780;
 									type="Land_CampingChair_V1_F";
@@ -27709,7 +28300,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3873;
 									type="Land_CampingChair_V1_F";
@@ -27727,7 +28318,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3874;
 									type="Land_CampingChair_V1_F";
@@ -27745,7 +28336,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3876;
 									type="Land_CampingChair_V1_F";
@@ -27763,7 +28354,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3877;
 									type="Land_CampingChair_V1_F";
@@ -27781,7 +28372,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3581;
 									type="Land_CampingChair_V1_folded_F";
@@ -27798,7 +28389,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3587;
 									type="Land_CampingChair_V1_folded_F";
@@ -27815,7 +28406,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3588;
 									type="Land_CampingChair_V1_folded_F";
@@ -27832,7 +28423,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3606;
 									type="Land_CampingChair_V1_folded_F";
@@ -27849,7 +28440,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3607;
 									type="Land_CampingChair_V1_folded_F";
@@ -27867,7 +28458,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3611;
 									type="Land_CampingChair_V1_folded_F";
@@ -27885,7 +28476,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3616;
 									type="Land_CampingChair_V1_folded_F";
@@ -27903,7 +28494,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3622;
 									type="Land_CampingChair_V1_folded_F";
@@ -27921,7 +28512,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3626;
 									type="Land_CampingChair_V1_folded_F";
@@ -27938,7 +28529,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3627;
 									type="Land_CampingChair_V1_folded_F";
@@ -27955,7 +28546,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3645;
 									type="Land_CampingChair_V1_folded_F";
@@ -27972,7 +28563,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3646;
 									type="Land_CampingChair_V1_folded_F";
@@ -27989,7 +28580,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3757;
 									type="Land_CampingChair_V1_folded_F";
@@ -28006,7 +28597,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3758;
 									type="Land_CampingChair_V1_folded_F";
@@ -28023,7 +28614,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3781;
 									type="Land_CampingChair_V1_folded_F";
@@ -28040,7 +28631,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3628;
 									type="Land_RowBoat_V1_F";
@@ -28058,7 +28649,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3632;
 									type="Land_RowBoat_V1_F";
@@ -28076,7 +28667,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3630;
 									type="Land_RowBoat_V2_F";
@@ -28094,7 +28685,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3629;
 									type="Land_RowBoat_V3_F";
@@ -28112,7 +28703,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3631;
 									type="Land_RowBoat_V3_F";
@@ -28130,7 +28721,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3637;
 									type="Land_ToiletBox_F";
@@ -28147,7 +28738,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3766;
 									type="Land_ToiletBox_F";
@@ -28164,7 +28755,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3802;
 									type="Land_ToiletBox_F";
@@ -28182,7 +28773,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3878;
 									type="Land_ToiletBox_F";
@@ -28199,7 +28790,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3911;
 									type="Campfire_burning_F";
@@ -28217,7 +28808,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3912;
 									type="Land_CampingChair_V1_F";
@@ -28235,7 +28826,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3913;
 									type="Land_CampingChair_V1_F";
@@ -28253,7 +28844,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3914;
 									type="Land_CampingChair_V1_folded_F";
@@ -28270,7 +28861,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3916;
 									type="Land_Bench_01_F";
@@ -28287,7 +28878,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3917;
 									type="Campfire_burning_F";
@@ -28305,7 +28896,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3918;
 									type="Land_CampingChair_V1_F";
@@ -28323,7 +28914,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3919;
 									type="Land_CampingChair_V1_F";
@@ -28341,7 +28932,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3920;
 									type="Land_CampingChair_V1_F";
@@ -28359,7 +28950,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3921;
 									type="Land_Bench_01_F";
@@ -28376,7 +28967,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3923;
 									type="Land_Bench_01_F";
@@ -28393,7 +28984,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3924;
 									type="Campfire_burning_F";
@@ -28411,7 +29002,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3925;
 									type="Land_CampingChair_V1_F";
@@ -28429,7 +29020,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3926;
 									type="Land_CampingChair_V1_F";
@@ -28447,7 +29038,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3927;
 									type="Land_CampingChair_V1_F";
@@ -28465,7 +29056,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3928;
 									type="Land_CampingChair_V1_folded_F";
@@ -28482,7 +29073,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3929;
 									type="Land_Bench_01_F";
@@ -28499,7 +29090,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3922;
 									type="Land_CampingChair_V1_folded_F";
@@ -28516,6 +29107,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
+										dynamicSimulation=1;
 									};
 									id=3910;
 									type="Land_LifeguardTower_01_F";
@@ -28532,7 +29124,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3956;
 									type="FirePlace_burning_F";
@@ -28550,7 +29142,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3958;
 									type="FirePlace_burning_F";
@@ -28568,7 +29160,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3961;
 									type="FirePlace_burning_F";
@@ -28586,7 +29178,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3963;
 									type="FirePlace_burning_F";
@@ -28604,7 +29196,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3966;
 									type="FirePlace_burning_F";
@@ -28621,15 +29213,15 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3968;
 									type="FirePlace_burning_F";
-									atlOffset=1.2874603e-005;
+									atlOffset=0.00025725365;
 								};
 							};
 							id=1784;
-							atlOffset=0.003923893;
+							atlOffset=-0.026138783;
 						};
 						class Item3
 						{
@@ -28708,7 +29300,7 @@ class Mission
 						};
 					};
 					id=64;
-					atlOffset=-15.300381;
+					atlOffset=-15.781525;
 				};
 				class Item6
 				{
@@ -28813,7 +29405,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4046;
 									type="Land_ToiletBox_F";
@@ -28830,7 +29422,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4047;
 									type="Land_ToiletBox_F";
@@ -28848,7 +29440,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4049;
 									type="Land_Bench_01_F";
@@ -28865,7 +29457,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4050;
 									type="Land_Bench_01_F";
@@ -28882,7 +29474,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4051;
 									type="Land_Bench_01_F";
@@ -28899,7 +29491,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4052;
 									type="Land_Bench_01_F";
@@ -28916,7 +29508,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4058;
 									type="Campfire_burning_F";
@@ -28933,7 +29525,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4059;
 									type="Campfire_burning_F";
@@ -28951,7 +29543,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4060;
 									type="Campfire_burning_F";
@@ -28968,7 +29560,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4070;
 									type="Campfire_burning_F";
@@ -28986,7 +29578,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4061;
 									type="FirePlace_burning_F";
@@ -29003,7 +29595,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4062;
 									type="FirePlace_burning_F";
@@ -29020,7 +29612,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4063;
 									type="FirePlace_burning_F";
@@ -29037,7 +29629,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4066;
 									type="FirePlace_burning_F";
@@ -29053,7 +29645,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4067;
 									type="FirePlace_burning_F";
@@ -29069,7 +29661,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4068;
 									type="FirePlace_burning_F";
@@ -29086,7 +29678,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4053;
 									type="Land_CampingChair_V1_F";
@@ -29103,7 +29695,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4054;
 									type="Land_CampingChair_V1_F";
@@ -29120,7 +29712,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4055;
 									type="Land_CampingChair_V1_F";
@@ -29137,7 +29729,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4057;
 									type="Land_CampingChair_V1_F";
@@ -29154,7 +29746,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4056;
 									type="Land_CampingChair_V1_folded_F";
@@ -29171,7 +29763,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4048;
 									type="Land_ToiletBox_F";
@@ -29188,7 +29780,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4153;
 									type="Land_Bench_01_F";
@@ -29206,7 +29798,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4154;
 									type="Campfire_burning_F";
@@ -29224,7 +29816,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4113;
 									type="Land_Bench_01_F";
@@ -29242,7 +29834,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4114;
 									type="Land_Bench_01_F";
@@ -29259,7 +29851,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4091;
 									type="Campfire_burning_F";
@@ -29277,7 +29869,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4129;
 									type="Campfire_burning_F";
@@ -29294,7 +29886,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4151;
 									type="Campfire_burning_F";
@@ -29311,7 +29903,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4170;
 									type="Campfire_burning_F";
@@ -29329,7 +29921,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4075;
 									type="Land_ChairWood_F";
@@ -29346,7 +29938,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4076;
 									type="Land_ChairWood_F";
@@ -29363,7 +29955,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4092;
 									type="Land_ChairWood_F";
@@ -29380,7 +29972,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4093;
 									type="Land_ChairWood_F";
@@ -29398,7 +29990,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4094;
 									type="Land_ChairWood_F";
@@ -29415,7 +30007,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4104;
 									type="Land_ChairWood_F";
@@ -29432,7 +30024,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4105;
 									type="Land_ChairWood_F";
@@ -29449,7 +30041,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4106;
 									type="Land_ChairWood_F";
@@ -29466,7 +30058,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4107;
 									type="Land_ChairWood_F";
@@ -29483,7 +30075,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4120;
 									type="Land_ChairWood_F";
@@ -29500,7 +30092,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4123;
 									type="Land_ChairWood_F";
@@ -29518,7 +30110,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4124;
 									type="Land_ChairWood_F";
@@ -29535,7 +30127,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4138;
 									type="Land_ChairWood_F";
@@ -29552,7 +30144,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4139;
 									type="Land_ChairWood_F";
@@ -29569,7 +30161,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4146;
 									type="Land_ChairWood_F";
@@ -29586,7 +30178,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4148;
 									type="Land_ChairWood_F";
@@ -29604,7 +30196,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4077;
 									type="FirePlace_burning_F";
@@ -29621,7 +30213,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4102;
 									type="FirePlace_burning_F";
@@ -29638,7 +30230,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4121;
 									type="FirePlace_burning_F";
@@ -29655,7 +30247,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4122;
 									type="FirePlace_burning_F";
@@ -29672,7 +30264,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4140;
 									type="FirePlace_burning_F";
@@ -29689,7 +30281,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4147;
 									type="FirePlace_burning_F";
@@ -29706,7 +30298,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4071;
 									type="Land_CampingChair_V1_F";
@@ -29723,7 +30315,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4072;
 									type="Land_CampingChair_V1_F";
@@ -29741,7 +30333,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4073;
 									type="Land_CampingChair_V1_F";
@@ -29759,7 +30351,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4078;
 									type="Land_CampingChair_V1_F";
@@ -29777,7 +30369,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4081;
 									type="Land_CampingChair_V1_F";
@@ -29795,7 +30387,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4084;
 									type="Land_CampingChair_V1_F";
@@ -29812,7 +30404,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4085;
 									type="Land_CampingChair_V1_F";
@@ -29829,7 +30421,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4086;
 									type="Land_CampingChair_V1_F";
@@ -29846,7 +30438,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4088;
 									type="Land_CampingChair_V1_F";
@@ -29863,7 +30455,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4089;
 									type="Land_CampingChair_V1_F";
@@ -29881,7 +30473,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4130;
 									type="Land_CampingChair_V1_F";
@@ -29898,7 +30490,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4131;
 									type="Land_CampingChair_V1_F";
@@ -29915,7 +30507,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4149;
 									type="Land_CampingChair_V1_F";
@@ -29933,7 +30525,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4150;
 									type="Land_CampingChair_V1_F";
@@ -29951,7 +30543,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4156;
 									type="Land_CampingChair_V1_F";
@@ -29969,7 +30561,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4157;
 									type="Land_CampingChair_V1_F";
@@ -29987,7 +30579,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4168;
 									type="Land_CampingChair_V1_F";
@@ -30004,7 +30596,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4169;
 									type="Land_CampingChair_V1_F";
@@ -30022,7 +30614,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4074;
 									type="Land_CampingChair_V1_folded_F";
@@ -30040,7 +30632,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4082;
 									type="Land_CampingChair_V1_folded_F";
@@ -30057,7 +30649,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4083;
 									type="Land_CampingChair_V1_folded_F";
@@ -30074,7 +30666,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4087;
 									type="Land_CampingChair_V1_folded_F";
@@ -30092,7 +30684,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4090;
 									type="Land_CampingChair_V1_folded_F";
@@ -30109,7 +30701,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4132;
 									type="Land_CampingChair_V1_folded_F";
@@ -30126,7 +30718,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4152;
 									type="Land_CampingChair_V1_folded_F";
@@ -30144,7 +30736,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4158;
 									type="Land_CampingChair_V1_folded_F";
@@ -30152,7 +30744,7 @@ class Mission
 								};
 							};
 							id=1787;
-							atlOffset=0.080627441;
+							atlOffset=-0.095870972;
 						};
 						class Item2
 						{
@@ -30199,7 +30791,7 @@ class Mission
 						};
 					};
 					id=65;
-					atlOffset=2.5723114;
+					atlOffset=2.4883423;
 				};
 				class Item7
 				{
@@ -30515,7 +31107,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4865;
 									type="Land_BeachBooth_01_F";
@@ -30533,7 +31125,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4867;
 									type="Land_BeachBooth_01_F";
@@ -30551,7 +31143,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4871;
 									type="Land_BeachBooth_01_F";
@@ -30568,7 +31160,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4872;
 									type="Land_BeachBooth_01_F";
@@ -30586,7 +31178,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4987;
 									type="Land_Bench_01_F";
@@ -30604,7 +31196,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4995;
 									type="Land_Bench_01_F";
@@ -30621,7 +31213,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4996;
 									type="Land_Bench_01_F";
@@ -30638,7 +31230,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4802;
 									type="Land_Wreck_BMP2_F";
@@ -30656,7 +31248,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5033;
 									type="Land_Wreck_BRDM2_F";
@@ -30673,7 +31265,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4858;
 									type="Campfire_burning_F";
@@ -30691,7 +31283,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4859;
 									type="Campfire_burning_F";
@@ -30709,7 +31301,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4863;
 									type="Campfire_burning_F";
@@ -30727,7 +31319,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4870;
 									type="Campfire_burning_F";
@@ -30745,7 +31337,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4875;
 									type="Campfire_burning_F";
@@ -30762,7 +31354,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4912;
 									type="Campfire_burning_F";
@@ -30778,7 +31370,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4949;
 									type="Campfire_burning_F";
@@ -30795,7 +31387,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4992;
 									type="Campfire_burning_F";
@@ -30813,7 +31405,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5018;
 									type="Campfire_burning_F";
@@ -30831,7 +31423,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5030;
 									type="Campfire_burning_F";
@@ -30849,7 +31441,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5038;
 									type="Campfire_burning_F";
@@ -30865,7 +31457,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5040;
 									type="Campfire_burning_F";
@@ -30882,7 +31474,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5049;
 									type="Campfire_burning_F";
@@ -30900,7 +31492,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5057;
 									type="Campfire_burning_F";
@@ -30917,7 +31509,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4854;
 									type="Land_ChairWood_F";
@@ -30935,7 +31527,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4855;
 									type="Land_ChairWood_F";
@@ -30953,7 +31545,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4880;
 									type="Land_ChairWood_F";
@@ -30970,7 +31562,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4883;
 									type="Land_ChairWood_F";
@@ -30987,7 +31579,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4884;
 									type="Land_ChairWood_F";
@@ -31004,7 +31596,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4887;
 									type="Land_ChairWood_F";
@@ -31021,7 +31613,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4888;
 									type="Land_ChairWood_F";
@@ -31038,7 +31630,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4889;
 									type="Land_ChairWood_F";
@@ -31056,7 +31648,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4890;
 									type="Land_ChairWood_F";
@@ -31074,7 +31666,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4893;
 									type="Land_ChairWood_F";
@@ -31092,7 +31684,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4897;
 									type="Land_ChairWood_F";
@@ -31110,7 +31702,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4902;
 									type="Land_ChairWood_F";
@@ -31127,7 +31719,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4903;
 									type="Land_ChairWood_F";
@@ -31145,7 +31737,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4904;
 									type="Land_ChairWood_F";
@@ -31162,7 +31754,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4908;
 									type="Land_ChairWood_F";
@@ -31179,7 +31771,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4927;
 									type="Land_ChairWood_F";
@@ -31196,7 +31788,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4935;
 									type="Land_ChairWood_F";
@@ -31213,7 +31805,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4936;
 									type="Land_ChairWood_F";
@@ -31224,13 +31816,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={5105.0063,16.367439,3952.4492};
-										angles[]={-0,5.1248617,0};
+										angles[]={0,5.1248617,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4959;
 									type="Land_ChairWood_F";
@@ -31241,13 +31833,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={5106.5063,16.367439,3954.4492};
-										angles[]={-0,4.8909187,0};
+										angles[]={0,4.8909187,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4964;
 									type="Land_ChairWood_F";
@@ -31264,7 +31856,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4970;
 									type="Land_ChairWood_F";
@@ -31281,7 +31873,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4972;
 									type="Land_ChairWood_F";
@@ -31298,7 +31890,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4973;
 									type="Land_ChairWood_F";
@@ -31315,7 +31907,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4974;
 									type="Land_ChairWood_F";
@@ -31332,7 +31924,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4975;
 									type="Land_ChairWood_F";
@@ -31350,7 +31942,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4976;
 									type="Land_ChairWood_F";
@@ -31368,7 +31960,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4977;
 									type="Land_ChairWood_F";
@@ -31385,7 +31977,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4978;
 									type="Land_ChairWood_F";
@@ -31402,7 +31994,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4979;
 									type="Land_ChairWood_F";
@@ -31419,7 +32011,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4980;
 									type="Land_ChairWood_F";
@@ -31437,7 +32029,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4981;
 									type="Land_ChairWood_F";
@@ -31455,7 +32047,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4982;
 									type="Land_ChairWood_F";
@@ -31473,7 +32065,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4983;
 									type="Land_ChairWood_F";
@@ -31490,7 +32082,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4998;
 									type="Land_ChairWood_F";
@@ -31507,7 +32099,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4999;
 									type="Land_ChairWood_F";
@@ -31525,7 +32117,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5006;
 									type="Land_ChairWood_F";
@@ -31543,7 +32135,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5007;
 									type="Land_ChairWood_F";
@@ -31560,7 +32152,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4811;
 									type="FirePlace_burning_F";
@@ -31578,7 +32170,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4812;
 									type="FirePlace_burning_F";
@@ -31596,7 +32188,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4813;
 									type="FirePlace_burning_F";
@@ -31614,7 +32206,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4814;
 									type="FirePlace_burning_F";
@@ -31632,7 +32224,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4815;
 									type="FirePlace_burning_F";
@@ -31650,7 +32242,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4881;
 									type="FirePlace_burning_F";
@@ -31667,7 +32259,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4882;
 									type="FirePlace_burning_F";
@@ -31684,7 +32276,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4885;
 									type="FirePlace_burning_F";
@@ -31701,7 +32293,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4886;
 									type="FirePlace_burning_F";
@@ -31718,7 +32310,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4891;
 									type="FirePlace_burning_F";
@@ -31735,7 +32327,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4892;
 									type="FirePlace_burning_F";
@@ -31751,7 +32343,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4901;
 									type="FirePlace_burning_F";
@@ -31768,7 +32360,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4907;
 									type="FirePlace_burning_F";
@@ -31785,7 +32377,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4911;
 									type="FirePlace_burning_F";
@@ -31801,7 +32393,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4934;
 									type="FirePlace_burning_F";
@@ -31812,13 +32404,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={5109,16.416389,3952.5};
-										angles[]={-0,5.5551023,0};
+										angles[]={0,5.5551023,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4962;
 									type="FirePlace_burning_F";
@@ -31829,13 +32421,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={5088.5,16.416389,3997.5};
-										angles[]={-0,2.6326652,0};
+										angles[]={0,2.6326652,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4971;
 									type="FirePlace_burning_F";
@@ -31852,7 +32444,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4993;
 									type="FirePlace_burning_F";
@@ -31869,7 +32461,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5000;
 									type="FirePlace_burning_F";
@@ -31886,7 +32478,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5004;
 									type="FirePlace_burning_F";
@@ -31903,7 +32495,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4844;
 									type="Land_CampingChair_V1_F";
@@ -31921,7 +32513,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4845;
 									type="Land_CampingChair_V1_F";
@@ -31939,7 +32531,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4848;
 									type="Land_CampingChair_V1_F";
@@ -31957,7 +32549,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4849;
 									type="Land_CampingChair_V1_F";
@@ -31975,7 +32567,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4850;
 									type="Land_CampingChair_V1_F";
@@ -31993,7 +32585,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4851;
 									type="Land_CampingChair_V1_F";
@@ -32011,7 +32603,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4860;
 									type="Land_CampingChair_V1_F";
@@ -32029,7 +32621,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4861;
 									type="Land_CampingChair_V1_F";
@@ -32047,7 +32639,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4868;
 									type="Land_CampingChair_V1_F";
@@ -32065,7 +32657,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4873;
 									type="Land_CampingChair_V1_F";
@@ -32083,7 +32675,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4922;
 									type="Land_CampingChair_V1_F";
@@ -32100,7 +32692,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4923;
 									type="Land_CampingChair_V1_F";
@@ -32117,7 +32709,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4924;
 									type="Land_CampingChair_V1_F";
@@ -32134,7 +32726,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4925;
 									type="Land_CampingChair_V1_F";
@@ -32151,7 +32743,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4945;
 									type="Land_CampingChair_V1_F";
@@ -32169,7 +32761,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4947;
 									type="Land_CampingChair_V1_F";
@@ -32187,7 +32779,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4948;
 									type="Land_CampingChair_V1_F";
@@ -32205,7 +32797,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4953;
 									type="Land_CampingChair_V1_F";
@@ -32223,7 +32815,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4988;
 									type="Land_CampingChair_V1_F";
@@ -32241,7 +32833,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4989;
 									type="Land_CampingChair_V1_F";
@@ -32258,7 +32850,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5010;
 									type="Land_CampingChair_V1_F";
@@ -32276,7 +32868,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5011;
 									type="Land_CampingChair_V1_F";
@@ -32294,7 +32886,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5014;
 									type="Land_CampingChair_V1_F";
@@ -32312,7 +32904,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5015;
 									type="Land_CampingChair_V1_F";
@@ -32329,7 +32921,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5024;
 									type="Land_CampingChair_V1_F";
@@ -32347,7 +32939,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5025;
 									type="Land_CampingChair_V1_F";
@@ -32365,7 +32957,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5026;
 									type="Land_CampingChair_V1_F";
@@ -32383,7 +32975,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5027;
 									type="Land_CampingChair_V1_F";
@@ -32401,7 +32993,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5035;
 									type="Land_CampingChair_V1_F";
@@ -32418,7 +33010,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5036;
 									type="Land_CampingChair_V1_F";
@@ -32435,7 +33027,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5039;
 									type="Land_CampingChair_V1_F";
@@ -32452,7 +33044,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5043;
 									type="Land_CampingChair_V1_F";
@@ -32469,7 +33061,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5047;
 									type="Land_CampingChair_V1_F";
@@ -32487,7 +33079,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5048;
 									type="Land_CampingChair_V1_F";
@@ -32505,7 +33097,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5050;
 									type="Land_CampingChair_V1_F";
@@ -32523,7 +33115,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5055;
 									type="Land_CampingChair_V1_F";
@@ -32540,7 +33132,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5056;
 									type="Land_CampingChair_V1_F";
@@ -32558,7 +33150,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5058;
 									type="Land_CampingChair_V1_F";
@@ -32575,7 +33167,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4846;
 									type="Land_CampingChair_V1_folded_F";
@@ -32593,7 +33185,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4852;
 									type="Land_CampingChair_V1_folded_F";
@@ -32611,7 +33203,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4853;
 									type="Land_CampingChair_V1_folded_F";
@@ -32629,7 +33221,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4862;
 									type="Land_CampingChair_V1_folded_F";
@@ -32646,7 +33238,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4869;
 									type="Land_CampingChair_V1_folded_F";
@@ -32664,7 +33256,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4874;
 									type="Land_CampingChair_V1_folded_F";
@@ -32682,7 +33274,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4926;
 									type="Land_CampingChair_V1_folded_F";
@@ -32699,7 +33291,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4950;
 									type="Land_CampingChair_V1_folded_F";
@@ -32717,7 +33309,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4951;
 									type="Land_CampingChair_V1_folded_F";
@@ -32735,7 +33327,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4952;
 									type="Land_CampingChair_V1_folded_F";
@@ -32752,7 +33344,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4990;
 									type="Land_CampingChair_V1_folded_F";
@@ -32769,7 +33361,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4991;
 									type="Land_CampingChair_V1_folded_F";
@@ -32786,7 +33378,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5016;
 									type="Land_CampingChair_V1_folded_F";
@@ -32803,7 +33395,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5017;
 									type="Land_CampingChair_V1_folded_F";
@@ -32820,7 +33412,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5028;
 									type="Land_CampingChair_V1_folded_F";
@@ -32837,7 +33429,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5029;
 									type="Land_CampingChair_V1_folded_F";
@@ -32855,7 +33447,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5037;
 									type="Land_CampingChair_V1_folded_F";
@@ -32872,7 +33464,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5044;
 									type="Land_CampingChair_V1_folded_F";
@@ -32889,7 +33481,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5051;
 									type="Land_CampingChair_V1_folded_F";
@@ -32906,7 +33498,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5052;
 									type="Land_CampingChair_V1_folded_F";
@@ -32924,7 +33516,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5059;
 									type="Land_CampingChair_V1_folded_F";
@@ -32941,7 +33533,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5060;
 									type="Land_CampingChair_V1_folded_F";
@@ -32958,6 +33550,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
+										dynamicSimulation=1;
 									};
 									id=4842;
 									type="Land_LifeguardTower_01_F";
@@ -32975,6 +33568,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
+										dynamicSimulation=1;
 									};
 									id=4843;
 									type="Land_LifeguardTower_01_F";
@@ -32992,7 +33586,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4829;
 									type="Land_RowBoat_V1_F";
@@ -33010,7 +33604,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4833;
 									type="Land_RowBoat_V1_F";
@@ -33028,7 +33622,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4838;
 									type="Land_RowBoat_V1_F";
@@ -33046,7 +33640,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4841;
 									type="Land_RowBoat_V1_F";
@@ -33064,7 +33658,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4830;
 									type="Land_RowBoat_V2_F";
@@ -33082,7 +33676,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4832;
 									type="Land_RowBoat_V2_F";
@@ -33100,7 +33694,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4836;
 									type="Land_RowBoat_V2_F";
@@ -33118,7 +33712,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4831;
 									type="Land_RowBoat_V3_F";
@@ -33136,7 +33730,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4834;
 									type="Land_RowBoat_V3_F";
@@ -33154,7 +33748,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4837;
 									type="Land_RowBoat_V3_F";
@@ -33172,7 +33766,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4840;
 									type="Land_RowBoat_V3_F";
@@ -33190,7 +33784,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5032;
 									type="Land_Wreck_UAZ_F";
@@ -33208,7 +33802,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5023;
 									type="Land_Wreck_Ural_F";
@@ -33226,7 +33820,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4803;
 									type="Land_Sun_chair_F";
@@ -33243,7 +33837,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4804;
 									type="Land_Sun_chair_F";
@@ -33261,7 +33855,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4805;
 									type="Land_Sun_chair_F";
@@ -33279,7 +33873,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4806;
 									type="Land_Sun_chair_F";
@@ -33297,7 +33891,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4807;
 									type="Land_Sun_chair_F";
@@ -33315,7 +33909,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4808;
 									type="Land_Sun_chair_F";
@@ -33333,7 +33927,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4809;
 									type="Land_Sun_chair_F";
@@ -33351,7 +33945,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4810;
 									type="Land_Sun_chair_F";
@@ -33369,7 +33963,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4819;
 									type="Land_Sun_chair_F";
@@ -33387,7 +33981,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4824;
 									type="Land_Sun_chair_F";
@@ -33405,7 +33999,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4816;
 									type="Land_Sunshade_F";
@@ -33423,7 +34017,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4817;
 									type="Land_Sunshade_F";
@@ -33441,7 +34035,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4818;
 									type="Land_Sunshade_F";
@@ -33459,7 +34053,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4822;
 									type="Land_Sunshade_F";
@@ -33477,7 +34071,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4823;
 									type="Land_Sunshade_F";
@@ -33495,7 +34089,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5045;
 									type="Land_Wreck_T72_hull_F";
@@ -33513,7 +34107,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5053;
 									type="Land_Wreck_T72_hull_F";
@@ -33530,7 +34124,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5046;
 									type="Land_Wreck_T72_turret_F";
@@ -33548,7 +34142,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5054;
 									type="Land_Wreck_T72_turret_F";
@@ -33566,7 +34160,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4856;
 									type="Land_ToiletBox_F";
@@ -33584,7 +34178,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4878;
 									type="Land_ToiletBox_F";
@@ -33601,7 +34195,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5019;
 									type="Land_ToiletBox_F";
@@ -33618,7 +34212,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5021;
 									type="Land_ToiletBox_F";
@@ -33635,7 +34229,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5041;
 									type="Land_ToiletBox_F";
@@ -33652,7 +34246,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9975;
 									type="FirePlace_burning_F";
@@ -33670,7 +34264,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9976;
 									type="FirePlace_burning_F";
@@ -33688,7 +34282,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9977;
 									type="Land_ChairWood_F";
@@ -33705,7 +34299,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9978;
 									type="Land_ChairWood_F";
@@ -33722,7 +34316,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9979;
 									type="FirePlace_burning_F";
@@ -33739,7 +34333,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9980;
 									type="Land_ChairWood_F";
@@ -33756,7 +34350,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9981;
 									type="Land_ChairWood_F";
@@ -33773,7 +34367,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9984;
 									type="Land_Laptop_02_unfolded_F";
@@ -33949,7 +34543,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5135;
 									type="Land_Bench_01_F";
@@ -33967,7 +34561,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5143;
 									type="Land_Bench_01_F";
@@ -33985,7 +34579,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5193;
 									type="Land_Bench_01_F";
@@ -34003,7 +34597,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5138;
 									type="Campfire_burning_F";
@@ -34020,7 +34614,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5139;
 									type="Campfire_burning_F";
@@ -34038,7 +34632,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5146;
 									type="Campfire_burning_F";
@@ -34056,7 +34650,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5198;
 									type="Campfire_burning_F";
@@ -34074,7 +34668,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5199;
 									type="Campfire_burning_F";
@@ -34092,7 +34686,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5206;
 									type="Campfire_burning_F";
@@ -34110,7 +34704,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5149;
 									type="Land_ChairWood_F";
@@ -34128,7 +34722,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5152;
 									type="Land_ChairWood_F";
@@ -34146,7 +34740,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5154;
 									type="Land_ChairWood_F";
@@ -34158,13 +34752,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={7205.4351,124.0016,2318.6902};
-										angles[]={-0,3.464622,0};
+										angles[]={0,3.464622,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5157;
 									type="Land_ChairWood_F";
@@ -34175,13 +34769,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={7203.6479,124.0016,2320.2651};
-										angles[]={-0,4.4665613,0};
+										angles[]={0,4.4665613,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5158;
 									type="Land_ChairWood_F";
@@ -34192,13 +34786,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={7207.6255,124.0016,2319.1802};
-										angles[]={-0,2.539547,0};
+										angles[]={0,2.539547,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5159;
 									type="Land_ChairWood_F";
@@ -34209,13 +34803,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={7208.4131,124.0016,2321.6052};
-										angles[]={-0,1.0939758,0};
+										angles[]={0,1.0939758,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5160;
 									type="Land_ChairWood_F";
@@ -34226,13 +34820,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={7206.4771,124.0016,2323.2644};
-										angles[]={-0,0.21244806,0};
+										angles[]={0,0.21244806,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5161;
 									type="Land_ChairWood_F";
@@ -34243,13 +34837,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={7204.4351,124.0016,2322.6902};
-										angles[]={-0,5.6134601,0};
+										angles[]={0,5.6134601,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5162;
 									type="Land_ChairWood_F";
@@ -34260,13 +34854,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={7210.5063,124.0016,2334.4492};
-										angles[]={-0,0.91153735,0};
+										angles[]={0,0.91153735,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5171;
 									type="Land_ChairWood_F";
@@ -34283,7 +34877,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5174;
 									type="Land_ChairWood_F";
@@ -34300,7 +34894,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5180;
 									type="Land_ChairWood_F";
@@ -34318,7 +34912,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5181;
 									type="Land_ChairWood_F";
@@ -34336,7 +34930,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5182;
 									type="Land_ChairWood_F";
@@ -34353,7 +34947,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5184;
 									type="Land_ChairWood_F";
@@ -34371,7 +34965,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5185;
 									type="Land_ChairWood_F";
@@ -34388,7 +34982,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5186;
 									type="Land_ChairWood_F";
@@ -34405,7 +34999,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5190;
 									type="Land_ChairWood_F";
@@ -34422,7 +35016,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5191;
 									type="Land_ChairWood_F";
@@ -34433,13 +35027,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={7206,124.05055,2321};
-										angles[]={-0,2.539547,0};
+										angles[]={0,2.539547,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5164;
 									type="FirePlace_burning_F";
@@ -34450,13 +35044,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={7207.5,124.05055,2332};
-										angles[]={-0,0.88116997,0};
+										angles[]={0,0.88116997,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5172;
 									type="FirePlace_burning_F";
@@ -34473,7 +35067,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5173;
 									type="FirePlace_burning_F";
@@ -34490,7 +35084,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5176;
 									type="FirePlace_burning_F";
@@ -34508,7 +35102,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5179;
 									type="FirePlace_burning_F";
@@ -34525,7 +35119,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5187;
 									type="FirePlace_burning_F";
@@ -34542,7 +35136,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5188;
 									type="FirePlace_burning_F";
@@ -34560,7 +35154,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5192;
 									type="FirePlace_burning_F";
@@ -34577,7 +35171,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5136;
 									type="Land_CampingChair_V1_F";
@@ -34595,7 +35189,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5137;
 									type="Land_CampingChair_V1_F";
@@ -34613,7 +35207,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5140;
 									type="Land_CampingChair_V1_F";
@@ -34631,7 +35225,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5144;
 									type="Land_CampingChair_V1_F";
@@ -34649,7 +35243,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5145;
 									type="Land_CampingChair_V1_F";
@@ -34666,7 +35260,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5148;
 									type="Land_CampingChair_V1_F";
@@ -34684,7 +35278,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5194;
 									type="Land_CampingChair_V1_F";
@@ -34702,7 +35296,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5200;
 									type="Land_CampingChair_V1_F";
@@ -34720,7 +35314,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5207;
 									type="Land_CampingChair_V1_F";
@@ -34738,7 +35332,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5210;
 									type="Land_CampingChair_V1_F";
@@ -34756,7 +35350,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5141;
 									type="Land_CampingChair_V1_folded_F";
@@ -34774,7 +35368,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5147;
 									type="Land_CampingChair_V1_folded_F";
@@ -34792,7 +35386,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5195;
 									type="Land_CampingChair_V1_folded_F";
@@ -34810,7 +35404,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5197;
 									type="Land_CampingChair_V1_folded_F";
@@ -34828,7 +35422,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5202;
 									type="Land_CampingChair_V1_folded_F";
@@ -34846,7 +35440,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5208;
 									type="Land_CampingChair_V1_folded_F";
@@ -34863,7 +35457,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5211;
 									type="Land_CampingChair_V1_folded_F";
@@ -34881,7 +35475,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5142;
 									type="Land_ToiletBox_F";
@@ -34899,7 +35493,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5203;
 									type="Land_ToiletBox_F";
@@ -34917,7 +35511,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5209;
 									type="Land_ToiletBox_F";
@@ -35329,7 +35923,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5587;
 									type="Land_RowBoat_V1_F";
@@ -35347,7 +35941,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5590;
 									type="Land_RowBoat_V1_F";
@@ -35365,7 +35959,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5593;
 									type="Land_RowBoat_V1_F";
@@ -35383,7 +35977,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5596;
 									type="Land_RowBoat_V1_F";
@@ -35401,7 +35995,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5589;
 									type="Land_RowBoat_V2_F";
@@ -35419,7 +36013,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5594;
 									type="Land_RowBoat_V2_F";
@@ -35437,7 +36031,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5588;
 									type="Land_RowBoat_V3_F";
@@ -35455,7 +36049,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5595;
 									type="Land_RowBoat_V3_F";
@@ -35473,7 +36067,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5600;
 									type="Land_RowBoat_V3_F";
@@ -35491,7 +36085,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5601;
 									type="Land_RowBoat_V2_F";
@@ -35509,7 +36103,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5602;
 									type="Land_RowBoat_V1_F";
@@ -35527,7 +36121,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5603;
 									type="Land_RowBoat_V3_F";
@@ -35545,7 +36139,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5604;
 									type="Land_RowBoat_V2_F";
@@ -35563,6 +36157,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
+										dynamicSimulation=1;
 									};
 									id=5608;
 									type="Land_LifeguardTower_01_F";
@@ -35580,6 +36175,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
+										dynamicSimulation=1;
 									};
 									id=5609;
 									type="Land_LifeguardTower_01_F";
@@ -35597,6 +36193,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
+										dynamicSimulation=1;
 									};
 									id=5611;
 									type="Land_LifeguardTower_01_F";
@@ -35614,7 +36211,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5612;
 									type="Land_Sun_chair_F";
@@ -35632,7 +36229,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5613;
 									type="Land_Sun_chair_F";
@@ -35650,7 +36247,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5614;
 									type="Land_Sun_chair_F";
@@ -35668,7 +36265,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5615;
 									type="Land_Sun_chair_F";
@@ -35686,7 +36283,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5616;
 									type="Land_Sun_chair_F";
@@ -35704,7 +36301,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5617;
 									type="Land_Sun_chair_F";
@@ -35722,7 +36319,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5618;
 									type="Land_Sun_chair_F";
@@ -35740,7 +36337,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5619;
 									type="Land_Sun_chair_F";
@@ -35758,7 +36355,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5620;
 									type="Land_Sun_chair_F";
@@ -35776,7 +36373,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5621;
 									type="Land_Sun_chair_F";
@@ -35794,7 +36391,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5622;
 									type="Land_Sun_chair_F";
@@ -35812,7 +36409,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5623;
 									type="Land_Sun_chair_F";
@@ -35830,7 +36427,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5599;
 									type="Land_Wreck_Traw2_F";
@@ -35848,7 +36445,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5597;
 									type="Land_Wreck_Traw_F";
@@ -35866,7 +36463,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5653;
 									type="Land_CampingChair_V1_F";
@@ -35884,7 +36481,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5654;
 									type="Land_CampingChair_V1_F";
@@ -35902,7 +36499,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5657;
 									type="Land_CampingChair_V1_F";
@@ -35920,7 +36517,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5658;
 									type="Land_CampingChair_V1_F";
@@ -35938,7 +36535,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5660;
 									type="Land_CampingChair_V1_F";
@@ -35956,7 +36553,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5661;
 									type="Land_CampingChair_V1_F";
@@ -35974,11 +36571,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5663;
 									type="Land_CampingChair_V1_F";
-									atlOffset=0.015831232;
+									atlOffset=0.014910936;
 								};
 								class Item37
 								{
@@ -35992,7 +36589,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5670;
 									type="Land_CampingChair_V1_F";
@@ -36010,7 +36607,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5671;
 									type="Land_CampingChair_V1_F";
@@ -36028,7 +36625,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5677;
 									type="Land_CampingChair_V1_F";
@@ -36046,7 +36643,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5683;
 									type="Land_CampingChair_V1_F";
@@ -36064,7 +36661,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5684;
 									type="Land_CampingChair_V1_F";
@@ -36082,7 +36679,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5690;
 									type="Land_CampingChair_V1_F";
@@ -36100,7 +36697,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5656;
 									type="Land_CampingChair_V1_folded_F";
@@ -36118,7 +36715,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5659;
 									type="Land_CampingChair_V1_folded_F";
@@ -36136,7 +36733,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5662;
 									type="Land_CampingChair_V1_folded_F";
@@ -36154,7 +36751,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5664;
 									type="Land_CampingChair_V1_folded_F";
@@ -36172,7 +36769,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5678;
 									type="Land_CampingChair_V1_folded_F";
@@ -36190,7 +36787,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5689;
 									type="Land_CampingChair_V1_folded_F";
@@ -36208,7 +36805,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5632;
 									type="Land_Sunshade_F";
@@ -36226,7 +36823,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5633;
 									type="Land_Sunshade_F";
@@ -36244,7 +36841,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5634;
 									type="Land_Sunshade_F";
@@ -36262,7 +36859,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5635;
 									type="Land_Sunshade_F";
@@ -36280,7 +36877,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5636;
 									type="Land_Sunshade_F";
@@ -36298,7 +36895,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5637;
 									type="Land_Sunshade_F";
@@ -36316,7 +36913,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5639;
 									type="Land_Sunshade_03_F";
@@ -36334,7 +36931,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5645;
 									type="Land_Sunshade_03_F";
@@ -36352,7 +36949,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5651;
 									type="Land_Sunshade_03_F";
@@ -36370,7 +36967,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5642;
 									type="Land_Sunshade_04_F";
@@ -36388,7 +36985,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5648;
 									type="Land_Sunshade_04_F";
@@ -36406,7 +37003,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5808;
 									type="Land_Bench_01_F";
@@ -36424,7 +37021,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5971;
 									type="Land_Bench_01_F";
@@ -36441,7 +37038,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5990;
 									type="Land_Bench_01_F";
@@ -36458,7 +37055,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5695;
 									type="Land_Wreck_BMP2_F";
@@ -36476,7 +37073,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5696;
 									type="Land_Wreck_BMP2_F";
@@ -36494,7 +37091,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5708;
 									type="Land_Wreck_BMP2_F";
@@ -36512,7 +37109,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5718;
 									type="Land_Wreck_BMP2_F";
@@ -36530,7 +37127,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5694;
 									type="Land_Wreck_BRDM2_F";
@@ -36548,7 +37145,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5707;
 									type="Land_Wreck_BRDM2_F";
@@ -36566,7 +37163,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5715;
 									type="Land_Wreck_BRDM2_F";
@@ -36584,7 +37181,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5768;
 									type="Campfire_burning_F";
@@ -36602,7 +37199,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5789;
 									type="Campfire_burning_F";
@@ -36620,7 +37217,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5791;
 									type="Campfire_burning_F";
@@ -36638,7 +37235,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5792;
 									type="Campfire_burning_F";
@@ -36656,7 +37253,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5793;
 									type="Campfire_burning_F";
@@ -36674,7 +37271,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5794;
 									type="Campfire_burning_F";
@@ -36692,7 +37289,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5795;
 									type="Campfire_burning_F";
@@ -36710,7 +37307,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5797;
 									type="Campfire_burning_F";
@@ -36728,7 +37325,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5798;
 									type="Campfire_burning_F";
@@ -36746,7 +37343,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5799;
 									type="Campfire_burning_F";
@@ -36764,7 +37361,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5801;
 									type="Campfire_burning_F";
@@ -36782,7 +37379,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5823;
 									type="Campfire_burning_F";
@@ -36800,7 +37397,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5936;
 									type="Campfire_burning_F";
@@ -36817,7 +37414,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5989;
 									type="Campfire_burning_F";
@@ -36834,7 +37431,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5749;
 									type="Land_ChairWood_F";
@@ -36852,7 +37449,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5750;
 									type="Land_ChairWood_F";
@@ -36869,7 +37466,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5751;
 									type="Land_ChairWood_F";
@@ -36886,7 +37483,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5759;
 									type="Land_ChairWood_F";
@@ -36903,11 +37500,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5813;
 									type="Land_ChairWood_F";
-									atlOffset=-0.0014572144;
+									atlOffset=-0.0026283264;
 								};
 								class Item89
 								{
@@ -36921,7 +37518,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5814;
 									type="Land_ChairWood_F";
@@ -36939,7 +37536,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5815;
 									type="Land_ChairWood_F";
@@ -36956,11 +37553,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5818;
 									type="Land_ChairWood_F";
-									atlOffset=0.0012779236;
+									atlOffset=0.0011024475;
 								};
 								class Item92
 								{
@@ -36974,7 +37571,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5829;
 									type="Land_ChairWood_F";
@@ -36992,11 +37589,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5830;
 									type="Land_ChairWood_F";
-									atlOffset=-0.01473999;
+									atlOffset=-0.014476776;
 								};
 								class Item94
 								{
@@ -37010,7 +37607,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5831;
 									type="Land_ChairWood_F";
@@ -37028,7 +37625,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5832;
 									type="Land_ChairWood_F";
@@ -37046,7 +37643,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5833;
 									type="Land_ChairWood_F";
@@ -37064,7 +37661,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5836;
 									type="Land_ChairWood_F";
@@ -37076,13 +37673,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={9483.5068,28.070522,1562.4491};
-										angles[]={-0,2.1163261,-0};
+										angles[]={0,2.1163261,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5839;
 									type="Land_ChairWood_F";
@@ -37100,7 +37697,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5841;
 									type="Land_ChairWood_F";
@@ -37118,7 +37715,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5842;
 									type="Land_ChairWood_F";
@@ -37136,7 +37733,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5843;
 									type="Land_ChairWood_F";
@@ -37154,7 +37751,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5844;
 									type="Land_ChairWood_F";
@@ -37171,7 +37768,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5845;
 									type="Land_ChairWood_F";
@@ -37188,7 +37785,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5846;
 									type="Land_ChairWood_F";
@@ -37206,7 +37803,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5848;
 									type="Land_ChairWood_F";
@@ -37224,7 +37821,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5849;
 									type="Land_ChairWood_F";
@@ -37242,7 +37839,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5850;
 									type="Land_ChairWood_F";
@@ -37260,7 +37857,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5851;
 									type="Land_ChairWood_F";
@@ -37278,7 +37875,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5852;
 									type="Land_ChairWood_F";
@@ -37295,7 +37892,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5857;
 									type="Land_ChairWood_F";
@@ -37313,7 +37910,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5858;
 									type="Land_ChairWood_F";
@@ -37330,10 +37927,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5862;
 									type="Land_ChairWood_F";
+									atlOffset=-0.0012187958;
 								};
 								class Item113
 								{
@@ -37347,7 +37945,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5863;
 									type="Land_ChairWood_F";
@@ -37365,7 +37963,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5864;
 									type="Land_ChairWood_F";
@@ -37383,7 +37981,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5865;
 									type="Land_ChairWood_F";
@@ -37401,7 +37999,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5867;
 									type="Land_ChairWood_F";
@@ -37419,7 +38017,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5874;
 									type="Land_ChairWood_F";
@@ -37436,7 +38034,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5885;
 									type="Land_ChairWood_F";
@@ -37454,7 +38052,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5887;
 									type="Land_ChairWood_F";
@@ -37471,7 +38069,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5888;
 									type="Land_ChairWood_F";
@@ -37488,7 +38086,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5889;
 									type="Land_ChairWood_F";
@@ -37505,7 +38103,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5890;
 									type="Land_ChairWood_F";
@@ -37522,7 +38120,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5897;
 									type="Land_ChairWood_F";
@@ -37539,7 +38137,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5902;
 									type="Land_ChairWood_F";
@@ -37557,7 +38155,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5903;
 									type="Land_ChairWood_F";
@@ -37575,7 +38173,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5905;
 									type="Land_ChairWood_F";
@@ -37593,7 +38191,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5906;
 									type="Land_ChairWood_F";
@@ -37610,7 +38208,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5907;
 									type="Land_ChairWood_F";
@@ -37627,7 +38225,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5908;
 									type="Land_ChairWood_F";
@@ -37644,7 +38242,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5912;
 									type="Land_ChairWood_F";
@@ -37662,7 +38260,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5913;
 									type="Land_ChairWood_F";
@@ -37673,13 +38271,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={9875.5068,8.6424255,1575.9491};
-										angles[]={-0,3.0111794,0};
+										angles[]={0,3.0111794,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5916;
 									type="Land_ChairWood_F";
@@ -37696,7 +38294,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5918;
 									type="Land_ChairWood_F";
@@ -37713,7 +38311,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5919;
 									type="Land_ChairWood_F";
@@ -37731,7 +38329,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5920;
 									type="Land_ChairWood_F";
@@ -37749,7 +38347,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5924;
 									type="Land_ChairWood_F";
@@ -37767,7 +38365,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5925;
 									type="Land_ChairWood_F";
@@ -37785,7 +38383,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5926;
 									type="Land_ChairWood_F";
@@ -37803,7 +38401,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5927;
 									type="Land_ChairWood_F";
@@ -37821,7 +38419,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5928;
 									type="Land_ChairWood_F";
@@ -37839,11 +38437,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5929;
 									type="Land_ChairWood_F";
-									atlOffset=0.011788368;
+									atlOffset=0.011787415;
 								};
 								class Item142
 								{
@@ -37857,7 +38455,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5964;
 									type="Land_ChairWood_F";
@@ -37875,11 +38473,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5972;
 									type="Land_ChairWood_F";
-									atlOffset=0.083174706;
+									atlOffset=0.083148956;
 								};
 								class Item144
 								{
@@ -37893,7 +38491,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5973;
 									type="Land_ChairWood_F";
@@ -37911,7 +38509,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5769;
 									type="FirePlace_burning_F";
@@ -37929,11 +38527,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5770;
 									type="FirePlace_burning_F";
-									atlOffset=0.015727043;
+									atlOffset=0.014841318;
 								};
 								class Item147
 								{
@@ -37947,7 +38545,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5772;
 									type="FirePlace_burning_F";
@@ -37965,7 +38563,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5774;
 									type="FirePlace_burning_F";
@@ -37983,7 +38581,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5776;
 									type="FirePlace_burning_F";
@@ -38001,7 +38599,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5778;
 									type="FirePlace_burning_F";
@@ -38019,7 +38617,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5780;
 									type="FirePlace_burning_F";
@@ -38037,7 +38635,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5782;
 									type="FirePlace_burning_F";
@@ -38055,7 +38653,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5784;
 									type="FirePlace_burning_F";
@@ -38073,7 +38671,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5786;
 									type="FirePlace_burning_F";
@@ -38091,7 +38689,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5788;
 									type="FirePlace_burning_F";
@@ -38109,7 +38707,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5806;
 									type="FirePlace_burning_F";
@@ -38126,7 +38724,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5807;
 									type="FirePlace_burning_F";
@@ -38143,7 +38741,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5819;
 									type="FirePlace_burning_F";
@@ -38160,7 +38758,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5820;
 									type="FirePlace_burning_F";
@@ -38178,7 +38776,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5821;
 									type="FirePlace_burning_F";
@@ -38196,11 +38794,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5866;
 									type="FirePlace_burning_F";
-									atlOffset=-1.9073486e-006;
+									atlOffset=5.3405762e-005;
 								};
 								class Item162
 								{
@@ -38214,7 +38812,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5868;
 									type="FirePlace_burning_F";
@@ -38231,7 +38829,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5870;
 									type="FirePlace_burning_F";
@@ -38248,7 +38846,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5871;
 									type="FirePlace_burning_F";
@@ -38266,7 +38864,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5876;
 									type="FirePlace_burning_F";
@@ -38284,7 +38882,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5882;
 									type="FirePlace_burning_F";
@@ -38301,7 +38899,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5884;
 									type="FirePlace_burning_F";
@@ -38318,7 +38916,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5931;
 									type="FirePlace_burning_F";
@@ -38335,7 +38933,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5934;
 									type="FirePlace_burning_F";
@@ -38352,7 +38950,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5937;
 									type="FirePlace_burning_F";
@@ -38369,7 +38967,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5940;
 									type="FirePlace_burning_F";
@@ -38387,7 +38985,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5943;
 									type="FirePlace_burning_F";
@@ -38405,7 +39003,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5948;
 									type="FirePlace_burning_F";
@@ -38422,7 +39020,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5954;
 									type="FirePlace_burning_F";
@@ -38440,11 +39038,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5955;
 									type="FirePlace_burning_F";
-									atlOffset=-0.036202431;
+									atlOffset=-0.036201477;
 								};
 								class Item176
 								{
@@ -38458,7 +39056,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5957;
 									type="FirePlace_burning_F";
@@ -38476,7 +39074,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5959;
 									type="FirePlace_burning_F";
@@ -38488,13 +39086,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={9875,8.6913757,1579.5};
-										angles[]={-0,1.1614678,0};
+										angles[]={0,1.1614678,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5960;
 									type="FirePlace_burning_F";
@@ -38511,7 +39109,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5961;
 									type="FirePlace_burning_F";
@@ -38522,13 +39120,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={9872.5,8.7532911,1563.5};
-										angles[]={-0,2.0654709,0};
+										angles[]={0,2.0654709,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5975;
 									type="FirePlace_burning_F";
@@ -38546,7 +39144,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5719;
 									type="Land_CampingChair_V1_F";
@@ -38564,7 +39162,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5720;
 									type="Land_CampingChair_V1_F";
@@ -38582,7 +39180,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5722;
 									type="Land_CampingChair_V1_F";
@@ -38600,7 +39198,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5723;
 									type="Land_CampingChair_V1_F";
@@ -38618,7 +39216,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5724;
 									type="Land_CampingChair_V1_F";
@@ -38636,7 +39234,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5729;
 									type="Land_CampingChair_V1_F";
@@ -38654,7 +39252,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5731;
 									type="Land_CampingChair_V1_F";
@@ -38672,7 +39270,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5734;
 									type="Land_CampingChair_V1_F";
@@ -38690,7 +39288,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5736;
 									type="Land_CampingChair_V1_F";
@@ -38708,7 +39306,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5737;
 									type="Land_CampingChair_V1_F";
@@ -38726,7 +39324,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5738;
 									type="Land_CampingChair_V1_F";
@@ -38744,7 +39342,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5740;
 									type="Land_CampingChair_V1_F";
@@ -38762,7 +39360,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5741;
 									type="Land_CampingChair_V1_F";
@@ -38780,7 +39378,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5743;
 									type="Land_CampingChair_V1_F";
@@ -38798,7 +39396,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5744;
 									type="Land_CampingChair_V1_F";
@@ -38816,7 +39414,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5746;
 									type="Land_CampingChair_V1_F";
@@ -38834,7 +39432,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5747;
 									type="Land_CampingChair_V1_F";
@@ -38852,7 +39450,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5757;
 									type="Land_CampingChair_V1_F";
@@ -38870,7 +39468,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5758;
 									type="Land_CampingChair_V1_F";
@@ -38888,7 +39486,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5760;
 									type="Land_CampingChair_V1_F";
@@ -38906,7 +39504,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5765;
 									type="Land_CampingChair_V1_F";
@@ -38924,7 +39522,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5766;
 									type="Land_CampingChair_V1_F";
@@ -38942,7 +39540,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5803;
 									type="Land_CampingChair_V1_F";
@@ -38960,7 +39558,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5805;
 									type="Land_CampingChair_V1_F";
@@ -38978,7 +39576,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5824;
 									type="Land_CampingChair_V1_F";
@@ -38996,7 +39594,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5825;
 									type="Land_CampingChair_V1_F";
@@ -39014,7 +39612,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5826;
 									type="Land_CampingChair_V1_F";
@@ -39032,7 +39630,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5982;
 									type="Land_CampingChair_V1_F";
@@ -39049,7 +39647,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5983;
 									type="Land_CampingChair_V1_F";
@@ -39066,7 +39664,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5984;
 									type="Land_CampingChair_V1_F";
@@ -39083,7 +39681,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5985;
 									type="Land_CampingChair_V1_F";
@@ -39100,7 +39698,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5721;
 									type="Land_CampingChair_V1_folded_F";
@@ -39118,7 +39716,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5727;
 									type="Land_CampingChair_V1_folded_F";
@@ -39136,7 +39734,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5728;
 									type="Land_CampingChair_V1_folded_F";
@@ -39154,7 +39752,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5730;
 									type="Land_CampingChair_V1_folded_F";
@@ -39172,7 +39770,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5735;
 									type="Land_CampingChair_V1_folded_F";
@@ -39190,7 +39788,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5739;
 									type="Land_CampingChair_V1_folded_F";
@@ -39208,7 +39806,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5742;
 									type="Land_CampingChair_V1_folded_F";
@@ -39226,7 +39824,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5745;
 									type="Land_CampingChair_V1_folded_F";
@@ -39244,7 +39842,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5748;
 									type="Land_CampingChair_V1_folded_F";
@@ -39262,7 +39860,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5755;
 									type="Land_CampingChair_V1_folded_F";
@@ -39280,7 +39878,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5761;
 									type="Land_CampingChair_V1_folded_F";
@@ -39298,7 +39896,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5767;
 									type="Land_CampingChair_V1_folded_F";
@@ -39316,7 +39914,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5804;
 									type="Land_CampingChair_V1_folded_F";
@@ -39334,7 +39932,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5827;
 									type="Land_CampingChair_V1_folded_F";
@@ -39351,7 +39949,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5986;
 									type="Land_CampingChair_V1_folded_F";
@@ -39367,7 +39965,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5987;
 									type="Land_CampingChair_V1_folded_F";
@@ -39383,7 +39981,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5988;
 									type="Land_CampingChair_V1_folded_F";
@@ -39400,7 +39998,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5856;
 									type="Land_Laptop_02_unfolded_F";
@@ -39418,7 +40016,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5705;
 									type="Land_Wreck_UAZ_F";
@@ -39436,7 +40034,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5712;
 									type="Land_Wreck_UAZ_F";
@@ -39454,7 +40052,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5704;
 									type="Land_Wreck_Ural_F";
@@ -39472,7 +40070,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5709;
 									type="Land_Wreck_Ural_F";
@@ -39490,7 +40088,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5697;
 									type="Land_Wreck_T72_hull_F";
@@ -39508,7 +40106,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5699;
 									type="Land_Wreck_T72_hull_F";
@@ -39526,7 +40124,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5700;
 									type="Land_Wreck_T72_hull_F";
@@ -39544,7 +40142,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5713;
 									type="Land_Wreck_T72_hull_F";
@@ -39562,7 +40160,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5716;
 									type="Land_Wreck_T72_hull_F";
@@ -39579,7 +40177,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5698;
 									type="Land_Wreck_T72_turret_F";
@@ -39596,7 +40194,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5701;
 									type="Land_Wreck_T72_turret_F";
@@ -39614,7 +40212,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5703;
 									type="Land_Wreck_T72_turret_F";
@@ -39631,7 +40229,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5714;
 									type="Land_Wreck_T72_turret_F";
@@ -39649,7 +40247,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5717;
 									type="Land_Wreck_T72_turret_F";
@@ -39667,7 +40265,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6027;
 									type="Land_ChairWood_F";
@@ -39684,7 +40282,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6028;
 									type="FirePlace_burning_F";
@@ -39701,7 +40299,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5994;
 									type="Land_BeachBooth_01_F";
@@ -39719,7 +40317,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5995;
 									type="Land_BeachBooth_01_F";
@@ -39737,7 +40335,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5997;
 									type="Land_BeachBooth_01_F";
@@ -39755,7 +40353,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5998;
 									type="Land_BeachBooth_01_F";
@@ -39773,7 +40371,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6014;
 									type="Land_Bench_01_F";
@@ -39791,7 +40389,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6034;
 									type="Land_Bench_01_F";
@@ -39809,7 +40407,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6005;
 									type="Campfire_burning_F";
@@ -39827,7 +40425,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6006;
 									type="Campfire_burning_F";
@@ -39845,7 +40443,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6017;
 									type="Campfire_burning_F";
@@ -39863,7 +40461,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6032;
 									type="Campfire_burning_F";
@@ -39881,7 +40479,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6035;
 									type="Campfire_burning_F";
@@ -39899,7 +40497,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6044;
 									type="Campfire_burning_F";
@@ -39917,7 +40515,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6000;
 									type="Land_CampingChair_V1_F";
@@ -39935,7 +40533,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6004;
 									type="Land_CampingChair_V1_F";
@@ -39953,7 +40551,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6007;
 									type="Land_CampingChair_V1_F";
@@ -39971,7 +40569,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6008;
 									type="Land_CampingChair_V1_F";
@@ -39989,7 +40587,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6015;
 									type="Land_CampingChair_V1_F";
@@ -40007,7 +40605,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6016;
 									type="Land_CampingChair_V1_F";
@@ -40025,7 +40623,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6030;
 									type="Land_CampingChair_V1_F";
@@ -40043,7 +40641,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6036;
 									type="Land_CampingChair_V1_F";
@@ -40061,7 +40659,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6037;
 									type="Land_CampingChair_V1_F";
@@ -40079,7 +40677,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6038;
 									type="Land_CampingChair_V1_F";
@@ -40097,7 +40695,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6041;
 									type="Land_CampingChair_V1_F";
@@ -40115,7 +40713,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6002;
 									type="Land_CampingChair_V1_folded_F";
@@ -40133,7 +40731,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6009;
 									type="Land_CampingChair_V1_folded_F";
@@ -40151,7 +40749,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6019;
 									type="Land_CampingChair_V1_folded_F";
@@ -40169,7 +40767,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6020;
 									type="Land_CampingChair_V1_folded_F";
@@ -40187,7 +40785,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6031;
 									type="Land_CampingChair_V1_folded_F";
@@ -40205,7 +40803,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6039;
 									type="Land_CampingChair_V1_folded_F";
@@ -40223,7 +40821,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6040;
 									type="Land_CampingChair_V1_folded_F";
@@ -40240,7 +40838,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6042;
 									type="Land_CampingChair_V1_folded_F";
@@ -40258,7 +40856,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6021;
 									type="Land_ToiletBox_F";
@@ -40276,7 +40874,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6025;
 									type="Land_ToiletBox_F";
@@ -40294,7 +40892,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6026;
 									type="Land_ToiletBox_F";
@@ -40311,7 +40909,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6029;
 									type="Land_ToiletBox_F";
@@ -40329,7 +40927,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6043;
 									type="Land_ToiletBox_F";
@@ -40347,7 +40945,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6048;
 									type="Land_Wreck_HMMWV_F";
@@ -40365,7 +40963,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6052;
 									type="Campfire_burning_F";
@@ -40383,7 +40981,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6060;
 									type="Campfire_burning_F";
@@ -40401,7 +40999,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6068;
 									type="Campfire_burning_F";
@@ -40419,7 +41017,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6047;
 									type="Land_Wreck_Skodovka_F";
@@ -40437,7 +41035,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6050;
 									type="Land_ChairWood_F";
@@ -40454,7 +41052,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6051;
 									type="FirePlace_burning_F";
@@ -40472,7 +41070,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6053;
 									type="Land_CampingChair_V1_F";
@@ -40490,7 +41088,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6054;
 									type="Land_CampingChair_V1_F";
@@ -40508,7 +41106,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6056;
 									type="Land_CampingChair_V1_F";
@@ -40526,7 +41124,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6057;
 									type="Land_CampingChair_V1_F";
@@ -40543,7 +41141,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6063;
 									type="Land_CampingChair_V1_F";
@@ -40561,7 +41159,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6065;
 									type="Land_CampingChair_V1_F";
@@ -40579,7 +41177,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6066;
 									type="Land_CampingChair_V1_F";
@@ -40597,7 +41195,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6055;
 									type="Land_CampingChair_V1_folded_F";
@@ -40615,7 +41213,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6058;
 									type="Land_CampingChair_V1_folded_F";
@@ -40633,7 +41231,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6069;
 									type="Land_CampingChair_V1_folded_F";
@@ -40651,7 +41249,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6070;
 									type="Land_UWreck_FishingBoat_F";
@@ -40669,7 +41267,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6049;
 									type="Land_ToiletBox_F";
@@ -40687,7 +41285,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6062;
 									type="Land_ToiletBox_F";
@@ -40705,7 +41303,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6071;
 									type="Land_ChairWood_F";
@@ -40723,7 +41321,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6085;
 									type="Land_CampingChair_V1_F";
@@ -40741,7 +41339,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6086;
 									type="Land_CampingChair_V1_F";
@@ -40759,7 +41357,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6087;
 									type="Land_CampingChair_V1_folded_F";
@@ -40776,7 +41374,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6088;
 									type="Land_Wreck_T72_hull_F";
@@ -40794,7 +41392,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6089;
 									type="Land_Wreck_T72_turret_F";
@@ -40812,7 +41410,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6094;
 									type="Land_CampingChair_V1_folded_F";
@@ -40830,7 +41428,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6072;
 									type="Land_Bench_01_F";
@@ -40848,7 +41446,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6081;
 									type="Land_Bench_01_F";
@@ -40866,7 +41464,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6099;
 									type="Land_Campfire_F";
@@ -40884,7 +41482,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6073;
 									type="Campfire_burning_F";
@@ -40902,7 +41500,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6082;
 									type="Campfire_burning_F";
@@ -40920,7 +41518,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6090;
 									type="Campfire_burning_F";
@@ -40938,7 +41536,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6091;
 									type="Campfire_burning_F";
@@ -40956,7 +41554,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6092;
 									type="Campfire_burning_F";
@@ -40974,7 +41572,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6104;
 									type="Campfire_burning_F";
@@ -40991,7 +41589,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6074;
 									type="Land_CampingChair_V1_F";
@@ -41009,7 +41607,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6075;
 									type="Land_CampingChair_V1_F";
@@ -41027,7 +41625,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6079;
 									type="Land_CampingChair_V1_F";
@@ -41045,7 +41643,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6080;
 									type="Land_CampingChair_V1_F";
@@ -41063,7 +41661,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6097;
 									type="Land_CampingChair_V1_F";
@@ -41081,7 +41679,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6098;
 									type="Land_CampingChair_V1_F";
@@ -41099,7 +41697,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6101;
 									type="Land_CampingChair_V1_F";
@@ -41117,7 +41715,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6105;
 									type="Land_CampingChair_V1_F";
@@ -41135,7 +41733,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6106;
 									type="Land_CampingChair_V1_F";
@@ -41153,7 +41751,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6109;
 									type="Land_CampingChair_V1_F";
@@ -41171,7 +41769,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6076;
 									type="Land_CampingChair_V1_folded_F";
@@ -41189,7 +41787,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6077;
 									type="Land_CampingChair_V1_folded_F";
@@ -41207,7 +41805,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6083;
 									type="Land_CampingChair_V1_folded_F";
@@ -41225,7 +41823,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6084;
 									type="Land_CampingChair_V1_folded_F";
@@ -41243,7 +41841,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6100;
 									type="Land_CampingChair_V1_folded_F";
@@ -41261,7 +41859,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6102;
 									type="Land_CampingChair_V1_folded_F";
@@ -41279,7 +41877,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6108;
 									type="Land_CampingChair_V1_folded_F";
@@ -41297,7 +41895,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6110;
 									type="Land_CampingChair_V1_folded_F";
@@ -41315,7 +41913,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6111;
 									type="Land_CampingChair_V1_folded_F";
@@ -41333,7 +41931,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6103;
 									type="Land_Wreck_UAZ_F";
@@ -41351,7 +41949,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6095;
 									type="Land_Wreck_Ural_F";
@@ -41369,7 +41967,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6142;
 									type="Land_Bench_01_F";
@@ -41387,7 +41985,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6143;
 									type="Campfire_burning_F";
@@ -41405,7 +42003,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6144;
 									type="Land_CampingChair_V1_F";
@@ -41423,7 +42021,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6145;
 									type="Land_CampingChair_V1_F";
@@ -41441,7 +42039,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6146;
 									type="Land_CampingChair_V1_folded_F";
@@ -41459,7 +42057,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6147;
 									type="Land_CampingChair_V1_folded_F";
@@ -41477,7 +42075,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9986;
 									type="FirePlace_burning_F";
@@ -41485,7 +42083,7 @@ class Mission
 								};
 							};
 							id=1795;
-							atlOffset=-0.96894264;
+							atlOffset=0.44445229;
 						};
 						class Item3
 						{
@@ -41548,7 +42146,7 @@ class Mission
 						};
 					};
 					id=68;
-					atlOffset=3.9771051;
+					atlOffset=2.2829294;
 				};
 				class Item10
 				{
@@ -41653,7 +42251,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6153;
 									type="Land_Bench_01_F";
@@ -41671,7 +42269,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6220;
 									type="Land_Wreck_BMP2_F";
@@ -41689,7 +42287,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6269;
 									type="Land_Campfire_F";
@@ -41707,7 +42305,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6152;
 									type="Campfire_burning_F";
@@ -41725,7 +42323,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6163;
 									type="Campfire_burning_F";
@@ -41743,7 +42341,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6207;
 									type="Campfire_burning_F";
@@ -41761,7 +42359,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6226;
 									type="Campfire_burning_F";
@@ -41779,7 +42377,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6228;
 									type="Campfire_burning_F";
@@ -41797,7 +42395,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6229;
 									type="Campfire_burning_F";
@@ -41815,7 +42413,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6252;
 									type="Campfire_burning_F";
@@ -41833,7 +42431,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6262;
 									type="Campfire_burning_F";
@@ -41850,7 +42448,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6268;
 									type="Campfire_burning_F";
@@ -41868,7 +42466,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6148;
 									type="Land_ChairWood_F";
@@ -41886,7 +42484,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6149;
 									type="Land_ChairWood_F";
@@ -41904,7 +42502,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6164;
 									type="Land_ChairWood_F";
@@ -41922,7 +42520,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6165;
 									type="Land_ChairWood_F";
@@ -41940,7 +42538,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6166;
 									type="Land_ChairWood_F";
@@ -41957,7 +42555,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6167;
 									type="Land_ChairWood_F";
@@ -41974,7 +42572,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6168;
 									type="Land_ChairWood_F";
@@ -41991,7 +42589,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6169;
 									type="Land_ChairWood_F";
@@ -42009,7 +42607,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6170;
 									type="Land_ChairWood_F";
@@ -42027,7 +42625,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6172;
 									type="Land_ChairWood_F";
@@ -42044,7 +42642,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6173;
 									type="Land_ChairWood_F";
@@ -42055,13 +42653,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={9133.5068,62.587219,2176.4492};
-										angles[]={-0,0.74258024,0.0039967569};
+										angles[]={0,0.74258024,0.0039967569};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6175;
 									type="Land_ChairWood_F";
@@ -42073,13 +42671,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={9130.0068,62.499371,2170.4492};
-										angles[]={-0,3.6158652,0.0039967569};
+										angles[]={0,3.6158652,0.0039967569};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6176;
 									type="Land_ChairWood_F";
@@ -42091,13 +42689,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={9133.0068,62.584755,2171.4492};
-										angles[]={-0,2.5561593,0.0039967569};
+										angles[]={0,2.5561593,0.0039967569};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6178;
 									type="Land_ChairWood_F";
@@ -42115,7 +42713,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6188;
 									type="Land_ChairWood_F";
@@ -42133,7 +42731,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6191;
 									type="Land_ChairWood_F";
@@ -42150,7 +42748,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6150;
 									type="FirePlace_burning_F";
@@ -42167,7 +42765,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6151;
 									type="FirePlace_burning_F";
@@ -42185,7 +42783,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6184;
 									type="FirePlace_burning_F";
@@ -42202,7 +42800,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6185;
 									type="FirePlace_burning_F";
@@ -42219,7 +42817,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6186;
 									type="FirePlace_burning_F";
@@ -42237,7 +42835,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6187;
 									type="FirePlace_burning_F";
@@ -42254,7 +42852,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6189;
 									type="FirePlace_burning_F";
@@ -42271,7 +42869,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6193;
 									type="FirePlace_burning_F";
@@ -42288,7 +42886,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6154;
 									type="Land_CampingChair_V1_F";
@@ -42306,7 +42904,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6155;
 									type="Land_CampingChair_V1_F";
@@ -42324,7 +42922,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6156;
 									type="Land_CampingChair_V1_F";
@@ -42342,7 +42940,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6160;
 									type="Land_CampingChair_V1_F";
@@ -42360,7 +42958,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6161;
 									type="Land_CampingChair_V1_F";
@@ -42378,7 +42976,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6201;
 									type="Land_CampingChair_V1_F";
@@ -42396,7 +42994,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6208;
 									type="Land_CampingChair_V1_F";
@@ -42414,7 +43012,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6221;
 									type="Land_CampingChair_V1_F";
@@ -42432,7 +43030,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6222;
 									type="Land_CampingChair_V1_F";
@@ -42450,7 +43048,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6224;
 									type="Land_CampingChair_V1_F";
@@ -42468,7 +43066,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6230;
 									type="Land_CampingChair_V1_F";
@@ -42486,7 +43084,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6231;
 									type="Land_CampingChair_V1_F";
@@ -42504,7 +43102,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6235;
 									type="Land_CampingChair_V1_F";
@@ -42522,7 +43120,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6236;
 									type="Land_CampingChair_V1_F";
@@ -42540,7 +43138,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6239;
 									type="Land_CampingChair_V1_F";
@@ -42558,7 +43156,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6240;
 									type="Land_CampingChair_V1_F";
@@ -42576,7 +43174,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6241;
 									type="Land_CampingChair_V1_F";
@@ -42594,7 +43192,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6251;
 									type="Land_CampingChair_V1_F";
@@ -42612,7 +43210,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6260;
 									type="Land_CampingChair_V1_F";
@@ -42630,7 +43228,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6265;
 									type="Land_CampingChair_V1_F";
@@ -42648,7 +43246,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6266;
 									type="Land_CampingChair_V1_F";
@@ -42666,7 +43264,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6270;
 									type="Land_CampingChair_V1_F";
@@ -42684,7 +43282,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6271;
 									type="Land_CampingChair_V1_F";
@@ -42702,7 +43300,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6157;
 									type="Land_CampingChair_V1_folded_F";
@@ -42720,7 +43318,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6158;
 									type="Land_CampingChair_V1_folded_F";
@@ -42738,7 +43336,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6162;
 									type="Land_CampingChair_V1_folded_F";
@@ -42756,7 +43354,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6204;
 									type="Land_CampingChair_V1_folded_F";
@@ -42774,7 +43372,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6205;
 									type="Land_CampingChair_V1_folded_F";
@@ -42792,7 +43390,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6206;
 									type="Land_CampingChair_V1_folded_F";
@@ -42810,7 +43408,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6210;
 									type="Land_CampingChair_V1_folded_F";
@@ -42828,7 +43426,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6223;
 									type="Land_CampingChair_V1_folded_F";
@@ -42846,7 +43444,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6225;
 									type="Land_CampingChair_V1_folded_F";
@@ -42864,7 +43462,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6232;
 									type="Land_CampingChair_V1_folded_F";
@@ -42882,7 +43480,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6233;
 									type="Land_CampingChair_V1_folded_F";
@@ -42900,7 +43498,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6234;
 									type="Land_CampingChair_V1_folded_F";
@@ -42918,7 +43516,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6237;
 									type="Land_CampingChair_V1_folded_F";
@@ -42936,7 +43534,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6238;
 									type="Land_CampingChair_V1_folded_F";
@@ -42954,7 +43552,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6250;
 									type="Land_CampingChair_V1_folded_F";
@@ -42972,7 +43570,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6261;
 									type="Land_CampingChair_V1_folded_F";
@@ -42990,7 +43588,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6267;
 									type="Land_CampingChair_V1_folded_F";
@@ -43008,7 +43606,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6272;
 									type="Land_CampingChair_V1_folded_F";
@@ -43026,7 +43624,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6218;
 									type="Land_Wreck_UAZ_F";
@@ -43044,7 +43642,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6217;
 									type="Land_Wreck_Ural_F";
@@ -43062,7 +43660,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6219;
 									type="Land_Wreck_Ural_F";
@@ -43080,7 +43678,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6159;
 									type="Land_ToiletBox_F";
@@ -43098,7 +43696,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6248;
 									type="Land_ToiletBox_F";
@@ -43116,7 +43714,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6263;
 									type="Land_ToiletBox_F";
@@ -43134,7 +43732,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6264;
 									type="Land_ToiletBox_F";
@@ -43152,7 +43750,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6275;
 									type="Campfire_burning_F";
@@ -43170,7 +43768,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6273;
 									type="Land_CampingChair_V1_folded_F";
@@ -43188,7 +43786,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6274;
 									type="Land_CampingChair_V1_folded_F";
@@ -43200,20 +43798,20 @@ class Mission
 									class PositionInfo
 									{
 										position[]={9131.8359,62.629784,2174.0215};
-										angles[]={-0,0,0.0039967569};
+										angles[]={0,0,0.0039967569};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9993;
 									type="FirePlace_burning_F";
 								};
 							};
 							id=1797;
-							atlOffset=-0.7273674;
+							atlOffset=-0.72729111;
 						};
 						class Item2
 						{
@@ -43260,7 +43858,7 @@ class Mission
 						};
 					};
 					id=69;
-					atlOffset=-0.17834854;
+					atlOffset=-0.17833328;
 				};
 				class Item11
 				{
@@ -43365,7 +43963,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3142;
 									type="Land_Bench_01_F";
@@ -43382,7 +43980,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3143;
 									type="Land_Bench_01_F";
@@ -43399,7 +43997,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3150;
 									type="Land_Bench_01_F";
@@ -43416,7 +44014,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3165;
 									type="Land_Bench_01_F";
@@ -43433,7 +44031,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3168;
 									type="Campfire_burning_F";
@@ -43450,7 +44048,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3145;
 									type="Land_ChairWood_F";
@@ -43468,7 +44066,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3146;
 									type="Land_ChairWood_F";
@@ -43485,7 +44083,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3153;
 									type="Land_ChairWood_F";
@@ -43503,7 +44101,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3161;
 									type="Land_ChairWood_F";
@@ -43514,17 +44112,17 @@ class Mission
 									class PositionInfo
 									{
 										position[]={8804.2158,88.10228,2726.7922};
-										angles[]={-0,4.925786,6.2711902};
+										angles[]={0,4.925786,6.2711902};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3162;
 									type="Land_ChairWood_F";
-									atlOffset=7.6293945e-006;
+									atlOffset=0.00016021729;
 								};
 								class Item10
 								{
@@ -43538,7 +44136,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3175;
 									type="Land_ChairWood_F";
@@ -43556,7 +44154,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3177;
 									type="Land_ChairWood_F";
@@ -43574,7 +44172,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3144;
 									type="FirePlace_burning_F";
@@ -43591,7 +44189,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3147;
 									type="FirePlace_burning_F";
@@ -43608,7 +44206,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3154;
 									type="FirePlace_burning_F";
@@ -43619,13 +44217,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={8807.501,88.111649,2726};
-										angles[]={-0,1.3237286,6.2711902};
+										angles[]={0,1.3237286,6.2711902};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3163;
 									type="FirePlace_burning_F";
@@ -43642,7 +44240,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3167;
 									type="FirePlace_burning_F";
@@ -43659,7 +44257,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3178;
 									type="FirePlace_burning_F";
@@ -43676,7 +44274,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3169;
 									type="Land_CampingChair_V1_F";
@@ -43693,7 +44291,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3170;
 									type="Land_CampingChair_V1_F";
@@ -43710,7 +44308,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3171;
 									type="Land_CampingChair_V1_F";
@@ -43728,7 +44326,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3173;
 									type="Land_CampingChair_V1_F";
@@ -43746,7 +44344,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3172;
 									type="Land_CampingChair_V1_folded_F";
@@ -43763,7 +44361,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3174;
 									type="Land_CampingChair_V1_folded_F";
@@ -43781,7 +44379,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3332;
 									type="Land_ToiletBox_F";
@@ -43799,7 +44397,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3333;
 									type="Land_ToiletBox_F";
@@ -43816,7 +44414,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3334;
 									type="Land_ToiletBox_F";
@@ -43834,7 +44432,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3335;
 									type="Land_ToiletBox_F";
@@ -43852,14 +44450,14 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3336;
 									type="Land_ToiletBox_F";
 								};
 							};
 							id=1780;
-							atlOffset=-0.031364441;
+							atlOffset=-0.031227112;
 						};
 						class Item2
 						{
@@ -43906,7 +44504,7 @@ class Mission
 						};
 					};
 					id=70;
-					atlOffset=-0.037849426;
+					atlOffset=-0.037460327;
 				};
 				class Item12
 				{
@@ -44011,7 +44609,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4205;
 									type="Land_Bench_01_F";
@@ -44029,7 +44627,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4206;
 									type="Land_Bench_01_F";
@@ -44046,7 +44644,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4173;
 									type="Campfire_burning_F";
@@ -44064,7 +44662,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4175;
 									type="Campfire_burning_F";
@@ -44082,7 +44680,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4180;
 									type="Campfire_burning_F";
@@ -44100,7 +44698,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4181;
 									type="Campfire_burning_F";
@@ -44118,7 +44716,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4182;
 									type="Campfire_burning_F";
@@ -44136,7 +44734,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4198;
 									type="Land_ChairWood_F";
@@ -44153,7 +44751,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4199;
 									type="Land_ChairWood_F";
@@ -44170,7 +44768,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4200;
 									type="Land_ChairWood_F";
@@ -44188,7 +44786,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4201;
 									type="Land_ChairWood_F";
@@ -44205,7 +44803,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4202;
 									type="Land_ChairWood_F";
@@ -44223,7 +44821,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4203;
 									type="Land_ChairWood_F";
@@ -44241,7 +44839,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4204;
 									type="Land_ChairWood_F";
@@ -44259,10 +44857,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4177;
 									type="FirePlace_burning_F";
+									atlOffset=-7.6293945e-006;
 								};
 								class Item15
 								{
@@ -44276,7 +44875,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4178;
 									type="FirePlace_burning_F";
@@ -44293,7 +44892,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4207;
 									type="FirePlace_burning_F";
@@ -44311,7 +44910,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4176;
 									type="Land_FirePlace_F";
@@ -44328,7 +44927,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4188;
 									type="Land_CampingChair_V1_F";
@@ -44345,7 +44944,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4189;
 									type="Land_CampingChair_V1_F";
@@ -44363,7 +44962,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4191;
 									type="Land_CampingChair_V1_F";
@@ -44380,7 +44979,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4192;
 									type="Land_CampingChair_V1_F";
@@ -44398,7 +44997,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4194;
 									type="Land_CampingChair_V1_F";
@@ -44416,7 +45015,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4196;
 									type="Land_CampingChair_V1_F";
@@ -44433,7 +45032,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4210;
 									type="Land_CampingChair_V1_F";
@@ -44450,7 +45049,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4211;
 									type="Land_CampingChair_V1_F";
@@ -44467,7 +45066,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4212;
 									type="Land_CampingChair_V1_F";
@@ -44484,10 +45083,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4215;
 									type="Land_CampingChair_V1_F";
+									atlOffset=-1.5258789e-005;
 								};
 								class Item28
 								{
@@ -44501,7 +45101,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4216;
 									type="Land_CampingChair_V1_F";
@@ -44518,10 +45118,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4217;
 									type="Land_CampingChair_V1_F";
+									atlOffset=-4.5776367e-005;
 								};
 								class Item30
 								{
@@ -44535,7 +45136,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4190;
 									type="Land_CampingChair_V1_folded_F";
@@ -44553,7 +45154,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4193;
 									type="Land_CampingChair_V1_folded_F";
@@ -44570,7 +45171,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4195;
 									type="Land_CampingChair_V1_folded_F";
@@ -44588,7 +45189,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4197;
 									type="Land_CampingChair_V1_folded_F";
@@ -44606,7 +45207,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4213;
 									type="Land_CampingChair_V1_folded_F";
@@ -44624,7 +45225,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4214;
 									type="Land_CampingChair_V1_folded_F";
@@ -44642,10 +45243,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4218;
 									type="Land_CampingChair_V1_folded_F";
+									atlOffset=7.6293945e-006;
 								};
 								class Item37
 								{
@@ -44659,10 +45261,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4219;
 									type="Land_CampingChair_V1_folded_F";
+									atlOffset=7.6293945e-006;
 								};
 								class Item38
 								{
@@ -44676,7 +45279,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4171;
 									type="Land_ToiletBox_F";
@@ -44693,7 +45296,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4172;
 									type="Land_ToiletBox_F";
@@ -44711,7 +45314,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4223;
 									type="Land_ChairWood_F";
@@ -44729,7 +45332,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4225;
 									type="Land_FirePlace_F";
@@ -44747,14 +45350,14 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4227;
 									type="Land_ChairWood_F";
 								};
 							};
 							id=1788;
-							atlOffset=0.071975708;
+							atlOffset=0.092552185;
 						};
 						class Item2
 						{
@@ -44801,7 +45404,7 @@ class Mission
 						};
 					};
 					id=71;
-					atlOffset=0.41889191;
+					atlOffset=0.42073059;
 				};
 				class Item13
 				{
@@ -44906,7 +45509,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3952;
 									type="Land_Wreck_BMP2_F";
@@ -44924,7 +45527,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3953;
 									type="Land_Wreck_BRDM2_F";
@@ -44942,7 +45545,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3942;
 									type="Land_CampingChair_V1_F";
@@ -44960,7 +45563,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3944;
 									type="Land_CampingChair_V1_F";
@@ -44978,7 +45581,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3945;
 									type="Land_CampingChair_V1_F";
@@ -44996,7 +45599,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3946;
 									type="Land_CampingChair_V1_F";
@@ -45013,7 +45616,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3948;
 									type="Land_CampingChair_V1_F";
@@ -45030,7 +45633,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3947;
 									type="Land_CampingChair_V1_folded_F";
@@ -45047,7 +45650,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3949;
 									type="Land_CampingChair_V1_folded_F";
@@ -45064,6 +45667,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
+										dynamicSimulation=1;
 									};
 									id=3954;
 									type="Land_LifeguardTower_01_F";
@@ -45080,7 +45684,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3930;
 									type="Land_Sun_chair_F";
@@ -45097,7 +45701,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3931;
 									type="Land_Sun_chair_F";
@@ -45114,7 +45718,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3932;
 									type="Land_Sun_chair_F";
@@ -45131,7 +45735,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3933;
 									type="Land_Sun_chair_F";
@@ -45148,7 +45752,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3934;
 									type="Land_Sunshade_F";
@@ -45165,7 +45769,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3935;
 									type="Land_Sunshade_F";
@@ -45182,7 +45786,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3936;
 									type="Land_Sunshade_F";
@@ -45199,7 +45803,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3937;
 									type="Land_Sunshade_F";
@@ -45216,7 +45820,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3938;
 									type="Land_Sunshade_01_F";
@@ -45234,7 +45838,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3939;
 									type="Land_Sunshade_03_F";
@@ -45251,7 +45855,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3940;
 									type="Land_Sunshade_04_F";
@@ -45269,7 +45873,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3941;
 									type="Land_Sunshade_02_F";
@@ -45286,7 +45890,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3951;
 									type="Land_Wreck_Traw2_F";
@@ -45304,7 +45908,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3950;
 									type="Land_Wreck_Traw_F";
@@ -45322,7 +45926,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3972;
 									type="Land_Sun_chair_F";
@@ -45339,7 +45943,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3978;
 									type="Land_CampingChair_V1_F";
@@ -45357,7 +45961,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4000;
 									type="Land_BeachBooth_01_F";
@@ -45374,7 +45978,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4001;
 									type="Land_BeachBooth_01_F";
@@ -45391,7 +45995,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4016;
 									type="Land_Bench_01_F";
@@ -45408,7 +46012,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4029;
 									type="Land_Bench_01_F";
@@ -45425,7 +46029,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4032;
 									type="Land_Bench_01_F";
@@ -45442,7 +46046,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3979;
 									type="Campfire_burning_F";
@@ -45460,7 +46064,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3988;
 									type="Campfire_burning_F";
@@ -45477,7 +46081,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3989;
 									type="Campfire_burning_F";
@@ -45495,7 +46099,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4006;
 									type="Campfire_burning_F";
@@ -45512,7 +46116,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4022;
 									type="Campfire_burning_F";
@@ -45530,7 +46134,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4028;
 									type="Land_ChairWood_F";
@@ -45548,7 +46152,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3969;
 									type="FirePlace_burning_F";
@@ -45566,7 +46170,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3970;
 									type="FirePlace_burning_F";
@@ -45584,7 +46188,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3971;
 									type="FirePlace_burning_F";
@@ -45602,7 +46206,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3973;
 									type="FirePlace_burning_F";
@@ -45613,18 +46217,17 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={7651.5078,1.8385475,5697.0063};
-										angles[]={0.13221991,0,6.118691};
+										position[]={7651.5078,1.8385457,5697.0063};
+										angles[]={0.13222615,0,6.1186881};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3974;
 									type="FirePlace_burning_F";
-									atlOffset=1.7881393e-006;
 								};
 								class Item42
 								{
@@ -45638,7 +46241,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3975;
 									type="FirePlace_burning_F";
@@ -45656,7 +46259,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3976;
 									type="FirePlace_burning_F";
@@ -45673,7 +46276,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3977;
 									type="FirePlace_burning_F";
@@ -45691,7 +46294,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4031;
 									type="FirePlace_burning_F";
@@ -45708,7 +46311,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4034;
 									type="FirePlace_burning_F";
@@ -45725,7 +46328,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3980;
 									type="Land_CampingChair_V1_F";
@@ -45743,7 +46346,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3981;
 									type="Land_CampingChair_V1_F";
@@ -45760,7 +46363,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3983;
 									type="Land_CampingChair_V1_F";
@@ -45777,7 +46380,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3984;
 									type="Land_CampingChair_V1_F";
@@ -45795,7 +46398,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3985;
 									type="Land_CampingChair_V1_F";
@@ -45812,7 +46415,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3986;
 									type="Land_CampingChair_V1_F";
@@ -45830,7 +46433,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3987;
 									type="Land_CampingChair_V1_F";
@@ -45848,7 +46451,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4002;
 									type="Land_CampingChair_V1_F";
@@ -45865,7 +46468,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4004;
 									type="Land_CampingChair_V1_F";
@@ -45882,7 +46485,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4017;
 									type="Land_CampingChair_V1_F";
@@ -45900,7 +46503,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4018;
 									type="Land_CampingChair_V1_F";
@@ -45918,7 +46521,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4019;
 									type="Land_CampingChair_V1_F";
@@ -45936,7 +46539,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3982;
 									type="Land_CampingChair_V1_folded_F";
@@ -45953,7 +46556,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3990;
 									type="Land_CampingChair_V1_folded_F";
@@ -45971,7 +46574,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3991;
 									type="Land_CampingChair_V1_folded_F";
@@ -45989,7 +46592,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3992;
 									type="Land_CampingChair_V1_folded_F";
@@ -46007,7 +46610,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3993;
 									type="Land_CampingChair_V1_folded_F";
@@ -46024,7 +46627,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4005;
 									type="Land_CampingChair_V1_folded_F";
@@ -46041,7 +46644,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4021;
 									type="Land_CampingChair_V1_folded_F";
@@ -46058,7 +46661,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4023;
 									type="Land_CampingChair_V1_folded_F";
@@ -46075,7 +46678,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3994;
 									type="Land_RowBoat_V1_F";
@@ -46092,7 +46695,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3997;
 									type="Land_RowBoat_V1_F";
@@ -46110,7 +46713,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3995;
 									type="Land_RowBoat_V2_F";
@@ -46128,7 +46731,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3998;
 									type="Land_RowBoat_V3_F";
@@ -46145,7 +46748,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3999;
 									type="Land_RowBoat_V3_F";
@@ -46163,7 +46766,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4024;
 									type="Land_ToiletBox_F";
@@ -46180,7 +46783,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4038;
 									type="Land_ToiletBox_F";
@@ -46198,7 +46801,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4041;
 									type="Land_ChairWood_F";
@@ -46216,7 +46819,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4042;
 									type="Land_ChairWood_F";
@@ -46224,7 +46827,7 @@ class Mission
 								};
 							};
 							id=1395;
-							atlOffset=-2.0528908;
+							atlOffset=-2.0573273;
 						};
 						class Item2
 						{
@@ -46384,7 +46987,7 @@ class Mission
 						};
 					};
 					id=72;
-					atlOffset=-2.4558029;
+					atlOffset=-2.4554138;
 				};
 				class Item14
 				{
@@ -46488,7 +47091,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3096;
 									type="Land_Bench_01_F";
@@ -46506,7 +47109,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3097;
 									type="Land_Bench_01_F";
@@ -46523,7 +47126,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3099;
 									type="Land_Bench_01_F";
@@ -46541,7 +47144,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3109;
 									type="Land_Bench_01_F";
@@ -46558,7 +47161,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3111;
 									type="Land_Bench_01_F";
@@ -46575,7 +47178,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3112;
 									type="Land_Bench_01_F";
@@ -46593,7 +47196,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3115;
 									type="Land_Bench_01_F";
@@ -46610,7 +47213,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3116;
 									type="Land_Bench_01_F";
@@ -46627,7 +47230,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3117;
 									type="Campfire_burning_F";
@@ -46645,7 +47248,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3110;
 									type="Land_ChairWood_F";
@@ -46662,7 +47265,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3118;
 									type="Land_CampingChair_V1_F";
@@ -46679,7 +47282,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3119;
 									type="Land_CampingChair_V1_F";
@@ -46696,7 +47299,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3121;
 									type="Land_CampingChair_V1_F";
@@ -46713,7 +47316,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3120;
 									type="Land_CampingChair_V1_folded_F";
@@ -46730,7 +47333,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3125;
 									type="Land_Bench_01_F";
@@ -46747,7 +47350,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3131;
 									type="Land_Bench_01_F";
@@ -46764,7 +47367,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3127;
 									type="Land_ChairWood_F";
@@ -46781,7 +47384,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3128;
 									type="Land_ChairWood_F";
@@ -46799,7 +47402,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3129;
 									type="Land_ChairWood_F";
@@ -46817,7 +47420,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3130;
 									type="Land_ChairWood_F";
@@ -46835,7 +47438,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3132;
 									type="Land_ChairWood_F";
@@ -46852,7 +47455,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3133;
 									type="Land_ChairWood_F";
@@ -46868,7 +47471,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3134;
 									type="FirePlace_burning_F";
@@ -46885,7 +47488,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3137;
 									type="Land_RowBoat_V1_F";
@@ -46903,7 +47506,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3138;
 									type="Land_RowBoat_V2_F";
@@ -46921,7 +47524,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3140;
 									type="Land_RowBoat_V3_F";
@@ -46939,7 +47542,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3328;
 									type="Land_ToiletBox_F";
@@ -46956,7 +47559,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3329;
 									type="Land_ToiletBox_F";
@@ -46974,7 +47577,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3331;
 									type="Land_ToiletBox_F";
@@ -46992,7 +47595,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9969;
 									type="FirePlace_burning_F";
@@ -47010,14 +47613,14 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9970;
 									type="FirePlace_burning_F";
 								};
 							};
 							id=1779;
-							atlOffset=-0.015441895;
+							atlOffset=-0.028503418;
 						};
 						class Item2
 						{
@@ -47064,7 +47667,7 @@ class Mission
 						};
 					};
 					id=73;
-					atlOffset=0.0084915161;
+					atlOffset=0.0055999756;
 				};
 				class Item15
 				{
@@ -47169,7 +47772,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5106;
 									type="Land_Bench_01_F";
@@ -47187,7 +47790,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5102;
 									type="Campfire_burning_F";
@@ -47205,7 +47808,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5105;
 									type="Campfire_burning_F";
@@ -47223,7 +47826,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5115;
 									type="Campfire_burning_F";
@@ -47241,7 +47844,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5068;
 									type="Land_ChairWood_F";
@@ -47259,7 +47862,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5069;
 									type="Land_ChairWood_F";
@@ -47276,7 +47879,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5070;
 									type="Land_ChairWood_F";
@@ -47293,7 +47896,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5071;
 									type="Land_ChairWood_F";
@@ -47304,13 +47907,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={5498.5063,80.499344,6098.9492};
-										angles[]={-0,0.67513931,0};
+										angles[]={0,0.67513931,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5072;
 									type="Land_ChairWood_F";
@@ -47328,7 +47931,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5076;
 									type="Land_ChairWood_F";
@@ -47345,7 +47948,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5077;
 									type="Land_ChairWood_F";
@@ -47363,7 +47966,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5078;
 									type="Land_ChairWood_F";
@@ -47380,7 +47983,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5079;
 									type="Land_ChairWood_F";
@@ -47398,7 +48001,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5087;
 									type="FirePlace_burning_F";
@@ -47416,7 +48019,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5088;
 									type="FirePlace_burning_F";
@@ -47433,7 +48036,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5089;
 									type="FirePlace_burning_F";
@@ -47450,7 +48053,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5092;
 									type="FirePlace_burning_F";
@@ -47467,7 +48070,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5093;
 									type="FirePlace_burning_F";
@@ -47485,7 +48088,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5100;
 									type="Land_CampingChair_V1_F";
@@ -47503,7 +48106,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5107;
 									type="Land_CampingChair_V1_F";
@@ -47521,7 +48124,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5108;
 									type="Land_CampingChair_V1_F";
@@ -47539,11 +48142,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5109;
 									type="Land_CampingChair_V1_F";
-									atlOffset=-0.00042724609;
+									atlOffset=-0.00057220459;
 								};
 								class Item22
 								{
@@ -47557,7 +48160,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5110;
 									type="Land_CampingChair_V1_F";
@@ -47575,7 +48178,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5113;
 									type="Land_CampingChair_V1_F";
@@ -47593,7 +48196,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5117;
 									type="Land_CampingChair_V1_F";
@@ -47610,7 +48213,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5101;
 									type="Land_CampingChair_V1_folded_F";
@@ -47628,7 +48231,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5111;
 									type="Land_CampingChair_V1_folded_F";
@@ -47646,7 +48249,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5112;
 									type="Land_CampingChair_V1_folded_F";
@@ -47663,7 +48266,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5114;
 									type="Land_CampingChair_V1_folded_F";
@@ -47681,7 +48284,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5104;
 									type="Land_ToiletBox_F";
@@ -47699,7 +48302,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5116;
 									type="Land_ToiletBox_F";
@@ -47717,7 +48320,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5118;
 									type="Land_Bench_01_F";
@@ -47735,7 +48338,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5119;
 									type="Campfire_burning_F";
@@ -47753,7 +48356,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5120;
 									type="Land_CampingChair_V1_F";
@@ -47771,7 +48374,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5121;
 									type="Land_CampingChair_V1_F";
@@ -47789,7 +48392,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5122;
 									type="Land_CampingChair_V1_folded_F";
@@ -47807,7 +48410,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=5123;
 									type="Land_CampingChair_V1_folded_F";
@@ -47815,7 +48418,7 @@ class Mission
 								};
 							};
 							id=1792;
-							atlOffset=-0.0062408447;
+							atlOffset=-0.0063476563;
 						};
 						class Item2
 						{
@@ -47862,7 +48465,7 @@ class Mission
 						};
 					};
 					id=74;
-					atlOffset=-0.1867981;
+					atlOffset=-0.18678284;
 				};
 				class Item16
 				{
@@ -47966,7 +48569,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3368;
 									type="Land_ChairWood_F";
@@ -47984,7 +48587,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3369;
 									type="Land_ChairWood_F";
@@ -48001,7 +48604,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3370;
 									type="Land_ChairWood_F";
@@ -48018,7 +48621,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3376;
 									type="Land_ChairWood_F";
@@ -48035,7 +48638,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3378;
 									type="Land_ChairWood_F";
@@ -48052,7 +48655,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3379;
 									type="Land_ChairWood_F";
@@ -48069,7 +48672,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3380;
 									type="Land_ChairWood_F";
@@ -48085,7 +48688,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3358;
 									type="FirePlace_burning_F";
@@ -48102,7 +48705,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3377;
 									type="FirePlace_burning_F";
@@ -48119,7 +48722,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3393;
 									type="Land_Bench_01_F";
@@ -48136,7 +48739,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3395;
 									type="Land_Bench_01_F";
@@ -48154,7 +48757,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3396;
 									type="Land_Bench_01_F";
@@ -48171,7 +48774,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3397;
 									type="Land_Bench_01_F";
@@ -48188,7 +48791,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3401;
 									type="Land_Bench_01_F";
@@ -48205,7 +48808,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3402;
 									type="Land_Bench_01_F";
@@ -48222,7 +48825,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3403;
 									type="Land_Bench_01_F";
@@ -48239,7 +48842,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3405;
 									type="Land_Bench_01_F";
@@ -48257,7 +48860,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3406;
 									type="Land_Bench_01_F";
@@ -48274,7 +48877,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3414;
 									type="Land_Bench_01_F";
@@ -48291,7 +48894,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3404;
 									type="Campfire_burning_F";
@@ -48308,7 +48911,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3389;
 									type="Land_ChairWood_F";
@@ -48326,7 +48929,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3390;
 									type="Land_ChairWood_F";
@@ -48343,7 +48946,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3392;
 									type="Land_ChairWood_F";
@@ -48361,7 +48964,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3407;
 									type="Land_ChairWood_F";
@@ -48378,7 +48981,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3408;
 									type="Land_ChairWood_F";
@@ -48395,7 +48998,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3409;
 									type="Land_ChairWood_F";
@@ -48412,7 +49015,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3410;
 									type="Land_ChairWood_F";
@@ -48429,7 +49032,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3391;
 									type="FirePlace_burning_F";
@@ -48445,7 +49048,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3411;
 									type="FirePlace_burning_F";
@@ -48461,7 +49064,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3412;
 									type="FirePlace_burning_F";
@@ -48477,7 +49080,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3413;
 									type="FirePlace_burning_F";
@@ -48494,7 +49097,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3398;
 									type="Land_ToiletBox_F";
@@ -48512,7 +49115,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3399;
 									type="Land_ToiletBox_F";
@@ -48529,7 +49132,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3415;
 									type="Campfire_burning_F";
@@ -48546,7 +49149,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=3416;
 									type="Campfire_burning_F";
@@ -48562,7 +49165,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9971;
 									type="FirePlace_burning_F";
@@ -48579,7 +49182,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9972;
 									type="Land_Bench_01_F";
@@ -48738,7 +49341,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4637;
 									type="Land_Bench_01_F";
@@ -48755,7 +49358,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4643;
 									type="Land_Bench_01_F";
@@ -48772,7 +49375,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4667;
 									type="Land_Bench_01_F";
@@ -48789,7 +49392,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4668;
 									type="Land_Bench_01_F";
@@ -48806,7 +49409,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4669;
 									type="Land_Bench_01_F";
@@ -48823,7 +49426,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4694;
 									type="Land_Bench_01_F";
@@ -48841,7 +49444,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4697;
 									type="Land_Bench_01_F";
@@ -48858,7 +49461,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4700;
 									type="Land_Bench_01_F";
@@ -48875,7 +49478,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4701;
 									type="Land_Bench_01_F";
@@ -48892,7 +49495,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4705;
 									type="Land_Bench_01_F";
@@ -48910,7 +49513,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4706;
 									type="Land_Bench_01_F";
@@ -48928,7 +49531,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4801;
 									type="Land_Wreck_BMP2_F";
@@ -48946,7 +49549,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4715;
 									type="Campfire_burning_F";
@@ -48958,13 +49561,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4846.5,159.21727,7039.5};
-										angles[]={-0,2.1919353,0};
+										angles[]={0,2.1919353,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4722;
 									type="Campfire_burning_F";
@@ -48981,7 +49584,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4731;
 									type="Campfire_burning_F";
@@ -48998,7 +49601,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4732;
 									type="Campfire_burning_F";
@@ -49014,7 +49617,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4750;
 									type="Campfire_burning_F";
@@ -49031,7 +49634,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4797;
 									type="Campfire_burning_F";
@@ -49049,7 +49652,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4606;
 									type="Land_ChairWood_F";
@@ -49066,7 +49669,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4607;
 									type="Land_ChairWood_F";
@@ -49084,7 +49687,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4608;
 									type="Land_ChairWood_F";
@@ -49101,7 +49704,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4610;
 									type="Land_ChairWood_F";
@@ -49119,7 +49722,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4611;
 									type="Land_ChairWood_F";
@@ -49136,7 +49739,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4612;
 									type="Land_ChairWood_F";
@@ -49153,7 +49756,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4615;
 									type="Land_ChairWood_F";
@@ -49170,7 +49773,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4616;
 									type="Land_ChairWood_F";
@@ -49181,13 +49784,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4870.1553,158.91695,6971.5483};
-										angles[]={-0,0.52207464,0};
+										angles[]={0,0.52207464,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4620;
 									type="Land_ChairWood_F";
@@ -49198,13 +49801,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4871.1553,158.91695,6969.0483};
-										angles[]={-0,1.5798322,0};
+										angles[]={0,1.5798322,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4621;
 									type="Land_ChairWood_F";
@@ -49215,13 +49818,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4867.1553,158.91695,6970.5483};
-										angles[]={-0,4.9621391,0};
+										angles[]={0,4.9621391,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4622;
 									type="Land_ChairWood_F";
@@ -49232,13 +49835,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4868.0488,158.91695,6967.6411};
-										angles[]={-0,3.9044905,0};
+										angles[]={0,3.9044905,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4623;
 									type="Land_ChairWood_F";
@@ -49255,7 +49858,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4625;
 									type="Land_ChairWood_F";
@@ -49273,7 +49876,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4648;
 									type="Land_ChairWood_F";
@@ -49291,7 +49894,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4649;
 									type="Land_ChairWood_F";
@@ -49309,7 +49912,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4650;
 									type="Land_ChairWood_F";
@@ -49327,7 +49930,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4651;
 									type="Land_ChairWood_F";
@@ -49344,7 +49947,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4656;
 									type="Land_ChairWood_F";
@@ -49362,7 +49965,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4657;
 									type="Land_ChairWood_F";
@@ -49380,7 +49983,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4658;
 									type="Land_ChairWood_F";
@@ -49398,7 +50001,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4661;
 									type="Land_ChairWood_F";
@@ -49415,7 +50018,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4662;
 									type="Land_ChairWood_F";
@@ -49426,13 +50029,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4898.5063,158.91695,6928.4492};
-										angles[]={-0,2.5733428,0};
+										angles[]={0,2.5733428,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4670;
 									type="Land_ChairWood_F";
@@ -49449,7 +50052,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4673;
 									type="Land_ChairWood_F";
@@ -49466,7 +50069,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4674;
 									type="Land_ChairWood_F";
@@ -49477,13 +50080,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4923.0063,158.91658,6911.4492};
-										angles[]={-0,3.2708642,-0};
+										angles[]={0,3.2708642,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4677;
 									type="Land_ChairWood_F";
@@ -49495,13 +50098,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4952.5063,158.91661,6961.9492};
-										angles[]={0,5.7899861,-0};
+										angles[]={0,5.7899861,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4678;
 									type="Land_ChairWood_F";
@@ -49519,7 +50122,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4679;
 									type="Land_ChairWood_F";
@@ -49536,7 +50139,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4680;
 									type="Land_ChairWood_F";
@@ -49547,13 +50150,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4946.5063,158.91695,6968.9492};
-										angles[]={-0,3.3062098,0};
+										angles[]={0,3.3062098,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4685;
 									type="Land_ChairWood_F";
@@ -49564,13 +50167,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4950.5063,158.91687,6971.9492};
-										angles[]={-0,1.8463371,-0};
+										angles[]={0,1.8463371,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4686;
 									type="Land_ChairWood_F";
@@ -49587,7 +50190,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4687;
 									type="Land_ChairWood_F";
@@ -49604,7 +50207,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4688;
 									type="Land_ChairWood_F";
@@ -49621,7 +50224,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4692;
 									type="Land_ChairWood_F";
@@ -49639,7 +50242,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4707;
 									type="Land_ChairWood_F";
@@ -49656,7 +50259,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4708;
 									type="Land_ChairWood_F";
@@ -49674,7 +50277,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4758;
 									type="Land_ChairWood_F";
@@ -49691,7 +50294,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4759;
 									type="Land_ChairWood_F";
@@ -49708,7 +50311,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4761;
 									type="Land_ChairWood_F";
@@ -49725,7 +50328,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4762;
 									type="Land_ChairWood_F";
@@ -49742,7 +50345,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4763;
 									type="Land_ChairWood_F";
@@ -49760,7 +50363,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4764;
 									type="Land_ChairWood_F";
@@ -49778,7 +50381,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4766;
 									type="Land_ChairWood_F";
@@ -49795,7 +50398,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4768;
 									type="Land_ChairWood_F";
@@ -49811,7 +50414,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4770;
 									type="Land_ChairWood_F";
@@ -49829,7 +50432,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4773;
 									type="Land_ChairWood_F";
@@ -49847,7 +50450,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4774;
 									type="Land_ChairWood_F";
@@ -49864,7 +50467,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4777;
 									type="Land_ChairWood_F";
@@ -49882,7 +50485,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4778;
 									type="Land_ChairWood_F";
@@ -49900,7 +50503,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4779;
 									type="Land_ChairWood_F";
@@ -49918,7 +50521,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4780;
 									type="Land_ChairWood_F";
@@ -49936,7 +50539,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4781;
 									type="Land_ChairWood_F";
@@ -49954,7 +50557,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4782;
 									type="Land_ChairWood_F";
@@ -49972,7 +50575,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4783;
 									type="Land_ChairWood_F";
@@ -49990,7 +50593,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4785;
 									type="Land_ChairWood_F";
@@ -50007,7 +50610,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4786;
 									type="Land_ChairWood_F";
@@ -50025,7 +50628,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4790;
 									type="Land_ChairWood_F";
@@ -50043,7 +50646,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4791;
 									type="Land_ChairWood_F";
@@ -50060,7 +50663,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4717;
 									type="FirePlace_burning_F";
@@ -50077,7 +50680,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4718;
 									type="FirePlace_burning_F";
@@ -50094,7 +50697,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4720;
 									type="FirePlace_burning_F";
@@ -50111,7 +50714,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4724;
 									type="FirePlace_burning_F";
@@ -50129,7 +50732,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4725;
 									type="FirePlace_burning_F";
@@ -50146,7 +50749,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4727;
 									type="FirePlace_burning_F";
@@ -50163,7 +50766,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4728;
 									type="FirePlace_burning_F";
@@ -50180,7 +50783,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4730;
 									type="FirePlace_burning_F";
@@ -50191,13 +50794,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4948,158.9659,6971.5};
-										angles[]={-0,2.5687244,0};
+										angles[]={0,2.5687244,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4733;
 									type="FirePlace_burning_F";
@@ -50208,13 +50811,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4953,158.96545,6959};
-										angles[]={-0,5.1666751,-0};
+										angles[]={0,5.1666751,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4735;
 									type="FirePlace_burning_F";
@@ -50231,7 +50834,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4736;
 									type="FirePlace_burning_F";
@@ -50248,7 +50851,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4738;
 									type="FirePlace_burning_F";
@@ -50266,7 +50869,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4739;
 									type="FirePlace_burning_F";
@@ -50283,7 +50886,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4740;
 									type="FirePlace_burning_F";
@@ -50300,7 +50903,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4743;
 									type="FirePlace_burning_F";
@@ -50317,7 +50920,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4744;
 									type="FirePlace_burning_F";
@@ -50333,7 +50936,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4747;
 									type="FirePlace_burning_F";
@@ -50344,13 +50947,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4896.5,158.9659,6931.5};
-										angles[]={-0,2.0013769,0};
+										angles[]={0,2.0013769,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4751;
 									type="FirePlace_burning_F";
@@ -50367,7 +50970,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4753;
 									type="FirePlace_burning_F";
@@ -50384,7 +50987,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4755;
 									type="FirePlace_burning_F";
@@ -50401,7 +51004,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4756;
 									type="FirePlace_burning_F";
@@ -50417,7 +51020,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4775;
 									type="FirePlace_burning_F";
@@ -50428,13 +51031,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4925,159.04829,6912.5};
-										angles[]={-0,0,6.2812943};
+										angles[]={0,0,6.2812943};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4776;
 									type="FirePlace_burning_F";
@@ -50446,13 +51049,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4844,159.50534,7039.5};
-										angles[]={-0,3.9659419,0};
+										angles[]={0,3.9659419,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4626;
 									type="Land_CampingChair_V1_F";
@@ -50463,13 +51066,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4849,159.50534,7037.5};
-										angles[]={-0,2.1424227,0};
+										angles[]={0,2.1424227,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4628;
 									type="Land_CampingChair_V1_F";
@@ -50480,13 +51083,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4846,159.50534,7036.5};
-										angles[]={-0,3.2049334,0};
+										angles[]={0,3.2049334,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4632;
 									type="Land_CampingChair_V1_F";
@@ -50503,7 +51106,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4638;
 									type="Land_CampingChair_V1_F";
@@ -50521,7 +51124,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4639;
 									type="Land_CampingChair_V1_F";
@@ -50538,7 +51141,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4644;
 									type="Land_CampingChair_V1_F";
@@ -50555,7 +51158,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4645;
 									type="Land_CampingChair_V1_F";
@@ -50572,7 +51175,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4664;
 									type="Land_CampingChair_V1_F";
@@ -50589,7 +51192,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4665;
 									type="Land_CampingChair_V1_F";
@@ -50606,7 +51209,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4712;
 									type="Land_CampingChair_V1_F";
@@ -50624,7 +51227,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4713;
 									type="Land_CampingChair_V1_F";
@@ -50641,7 +51244,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4799;
 									type="Land_CampingChair_V1_F";
@@ -50653,13 +51256,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4845,159.06622,7042};
-										angles[]={-0,5.603014,0};
+										angles[]={0,5.603014,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4630;
 									type="Land_CampingChair_V1_folded_F";
@@ -50670,13 +51273,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4849,159.06622,7039};
-										angles[]={-0,2.3003423,0};
+										angles[]={0,2.3003423,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4631;
 									type="Land_CampingChair_V1_folded_F";
@@ -50687,13 +51290,13 @@ class Mission
 									class PositionInfo
 									{
 										position[]={4847.5,159.06622,7042};
-										angles[]={-0,0.93433285,0};
+										angles[]={0,0.93433285,0};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4633;
 									type="Land_CampingChair_V1_folded_F";
@@ -50710,7 +51313,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4640;
 									type="Land_CampingChair_V1_folded_F";
@@ -50727,7 +51330,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4641;
 									type="Land_CampingChair_V1_folded_F";
@@ -50745,7 +51348,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4646;
 									type="Land_CampingChair_V1_folded_F";
@@ -50762,7 +51365,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4647;
 									type="Land_CampingChair_V1_folded_F";
@@ -50779,7 +51382,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4666;
 									type="Land_CampingChair_V1_folded_F";
@@ -50796,7 +51399,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4714;
 									type="Land_CampingChair_V1_folded_F";
@@ -50814,7 +51417,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4800;
 									type="Land_CampingChair_V1_folded_F";
@@ -50832,7 +51435,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4709;
 									type="Land_ToiletBox_F";
@@ -50849,7 +51452,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4710;
 									type="Land_ToiletBox_F";
@@ -50867,7 +51470,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4711;
 									type="Land_ToiletBox_F";
@@ -50885,14 +51488,14 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=4798;
 									type="Land_ToiletBox_F";
 								};
 							};
 							id=1790;
-							atlOffset=-0.76844788;
+							atlOffset=-1.5273285;
 						};
 						class Item2
 						{
@@ -50955,11 +51558,11 @@ class Mission
 						};
 					};
 					id=80;
-					atlOffset=-0.15994263;
+					atlOffset=-0.35002136;
 				};
 			};
 			id=53;
-			atlOffset=51.808678;
+			atlOffset=51.757732;
 		};
 		class Item2
 		{
@@ -51096,7 +51699,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7251;
 									type="Land_Wreck_UAZ_F";
@@ -51114,7 +51717,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7325;
 									type="Land_Wreck_BRDM2_F";
@@ -51132,7 +51735,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7327;
 									type="Campfire_burning_F";
@@ -51150,7 +51753,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7328;
 									type="Land_Wreck_Skodovka_F";
@@ -51168,7 +51771,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7331;
 									type="Land_CampingChair_V1_F";
@@ -51186,7 +51789,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7332;
 									type="Land_CampingChair_V1_F";
@@ -51204,7 +51807,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7333;
 									type="Land_CampingChair_V1_F";
@@ -51222,7 +51825,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7334;
 									type="Land_CampingChair_V1_F";
@@ -51240,7 +51843,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7340;
 									type="Land_CampingChair_V1_folded_F";
@@ -51257,7 +51860,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7341;
 									type="Land_CampingChair_V1_folded_F";
@@ -51275,7 +51878,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7344;
 									type="TargetP_Inf_Acc2_F";
@@ -51293,7 +51896,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7345;
 									type="TargetP_Inf_Acc2_F";
@@ -51310,7 +51913,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7346;
 									type="TargetP_Inf_Acc2_F";
@@ -51327,7 +51930,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7347;
 									type="TargetP_Inf2_Acc2_F";
@@ -51345,7 +51948,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7348;
 									type="TargetP_Inf2_Acc2_F";
@@ -51362,7 +51965,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7349;
 									type="TargetP_Inf2_Acc2_F";
@@ -51379,7 +51982,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7350;
 									type="Land_Wreck_UAZ_F";
@@ -51397,7 +52000,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7351;
 									type="Land_Wreck_Ural_F";
@@ -51415,7 +52018,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7354;
 									type="Land_Shooting_range";
@@ -51433,7 +52036,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7357;
 									type="Land_Wreck_HMMWV_F";
@@ -51451,7 +52054,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7363;
 									type="Land_Wreck_Ural_F";
@@ -51469,7 +52072,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7364;
 									type="Land_Wreck_BMP2_F";
@@ -51487,7 +52090,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7365;
 									type="Land_Wreck_UAZ_F";
@@ -51505,7 +52108,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7366;
 									type="Land_Wreck_HMMWV_F";
@@ -51523,7 +52126,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7324;
 									type="Land_Wreck_BMP2_F";
@@ -51541,7 +52144,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7369;
 									type="Land_Shooting_range";
@@ -51559,7 +52162,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7371;
 									type="Land_Shooting_range";
@@ -51577,7 +52180,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7372;
 									type="Land_Shooting_range";
@@ -51595,7 +52198,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7373;
 									type="Land_Shooting_range";
@@ -51613,7 +52216,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7374;
 									type="Land_Shooting_range";
@@ -51631,7 +52234,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8970;
 									type="Land_CampingChair_V1_folded_F";
@@ -51649,7 +52252,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8971;
 									type="Land_CampingChair_V1_F";
@@ -51667,7 +52270,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8972;
 									type="Land_CampingChair_V1_F";
@@ -51685,7 +52288,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8973;
 									type="Land_CampingChair_V1_F";
@@ -51703,7 +52306,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8974;
 									type="Land_CampingChair_V1_F";
@@ -51721,7 +52324,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8975;
 									type="Land_CampingChair_V1_folded_F";
@@ -51738,7 +52341,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8976;
 									type="Campfire_burning_F";
@@ -51756,7 +52359,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8977;
 									type="Land_FieldToilet_F";
@@ -51774,7 +52377,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8978;
 									type="Land_FieldToilet_F";
@@ -51792,7 +52395,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8969;
 									type="Land_CampingChair_V1_folded_F";
@@ -51809,7 +52412,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8981;
 									type="Land_CampingChair_V1_F";
@@ -51827,7 +52430,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8982;
 									type="Land_CampingChair_V1_F";
@@ -51845,7 +52448,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8983;
 									type="Land_CampingChair_V1_folded_F";
@@ -51863,7 +52466,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8980;
 									type="Campfire_burning_F";
@@ -51881,7 +52484,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9240;
 									type="Campfire_burning_F";
@@ -51899,7 +52502,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9248;
 									type="Campfire_burning_F";
@@ -51917,7 +52520,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9241;
 									type="Land_CampingChair_V1_F";
@@ -51934,7 +52537,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9242;
 									type="Land_CampingChair_V1_F";
@@ -51952,7 +52555,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9243;
 									type="Land_CampingChair_V1_F";
@@ -51969,7 +52572,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9244;
 									type="Land_CampingChair_V1_F";
@@ -51987,7 +52590,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9245;
 									type="Land_CampingChair_V1_F";
@@ -52005,7 +52608,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9246;
 									type="Land_CampingChair_V1_F";
@@ -52023,7 +52626,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9247;
 									type="Land_CampingChair_V1_F";
@@ -52041,7 +52644,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9249;
 									type="Land_CampingChair_V1_folded_F";
@@ -52059,7 +52662,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9252;
 									type="Campfire_burning_F";
@@ -52077,7 +52680,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9255;
 									type="Land_ChairWood_F";
@@ -52095,7 +52698,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9256;
 									type="Land_ChairWood_F";
@@ -52113,7 +52716,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9253;
 									type="FirePlace_burning_F";
@@ -52131,7 +52734,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9254;
 									type="FirePlace_burning_F";
@@ -52149,7 +52752,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9250;
 									type="Land_CampingChair_V1_F";
@@ -52166,7 +52769,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9251;
 									type="Land_CampingChair_V1_F";
@@ -52184,7 +52787,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9304;
 									type="Campfire_burning_F";
@@ -52201,7 +52804,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9301;
 									type="Land_CampingChair_V1_F";
@@ -52218,7 +52821,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9302;
 									type="Land_CampingChair_V1_F";
@@ -52236,7 +52839,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9303;
 									type="Land_CampingChair_V1_folded_F";
@@ -52254,14 +52857,14 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9300;
 									type="Land_Wreck_Ural_F";
 								};
 							};
 							id=1801;
-							atlOffset=0.058929443;
+							atlOffset=0.0086669922;
 						};
 						class Item3
 						{
@@ -52382,6 +52985,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=7376;
 											type="Land_Hlaska";
@@ -52399,6 +53003,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=7375;
 											type="Land_Hlaska";
@@ -52664,7 +53269,7 @@ class Mission
 						};
 					};
 					id=58;
-					atlOffset=1.7899551;
+					atlOffset=1.7575531;
 				};
 				class Item1
 				{
@@ -52768,7 +53373,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9009;
 									type="Land_CampingChair_V1_F";
@@ -52786,7 +53391,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9010;
 									type="Land_CampingChair_V1_folded_F";
@@ -52804,7 +53409,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9011;
 									type="Campfire_burning_F";
@@ -52822,7 +53427,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9008;
 									type="Land_CampingChair_V1_F";
@@ -52840,7 +53445,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9131;
 									type="Land_CampingChair_V1_F";
@@ -52858,7 +53463,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9132;
 									type="Land_CampingChair_V1_F";
@@ -52876,7 +53481,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9133;
 									type="Land_CampingChair_V1_F";
@@ -52894,7 +53499,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9134;
 									type="Land_CampingChair_V1_folded_F";
@@ -52912,7 +53517,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9135;
 									type="Campfire_burning_F";
@@ -52930,7 +53535,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9136;
 									type="Land_FieldToilet_F";
@@ -52948,7 +53553,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9137;
 									type="Land_FieldToilet_F";
@@ -52966,7 +53571,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9138;
 									type="Land_CampingChair_V1_folded_F";
@@ -52983,7 +53588,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9139;
 									type="Land_CampingChair_V1_folded_F";
@@ -53000,7 +53605,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9130;
 									type="Land_CampingChair_V1_F";
@@ -53018,7 +53623,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9342;
 									type="Campfire_burning_F";
@@ -53036,7 +53641,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9334;
 									type="Land_ChairWood_F";
@@ -53053,7 +53658,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9335;
 									type="Land_ChairWood_F";
@@ -53070,7 +53675,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9337;
 									type="Land_ChairWood_F";
@@ -53088,7 +53693,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9339;
 									type="Land_ChairWood_F";
@@ -53105,7 +53710,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9340;
 									type="Land_ChairWood_F";
@@ -53122,7 +53727,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9349;
 									type="Land_ChairWood_F";
@@ -53140,11 +53745,11 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9356;
 									type="Land_ChairWood_F";
-									atlOffset=0.0018157959;
+									atlOffset=0.002038002;
 								};
 								class Item22
 								{
@@ -53158,7 +53763,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9333;
 									type="FirePlace_burning_F";
@@ -53175,7 +53780,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9336;
 									type="FirePlace_burning_F";
@@ -53192,7 +53797,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9341;
 									type="FirePlace_burning_F";
@@ -53209,7 +53814,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9357;
 									type="FirePlace_burning_F";
@@ -53227,7 +53832,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9343;
 									type="Land_CampingChair_V1_F";
@@ -53244,7 +53849,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9344;
 									type="Land_CampingChair_V1_F";
@@ -53261,7 +53866,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9345;
 									type="Land_CampingChair_V1_F";
@@ -53278,7 +53883,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9346;
 									type="Land_CampingChair_V1_folded_F";
@@ -53295,7 +53900,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9347;
 									type="Land_CampingChair_V1_folded_F";
@@ -53312,7 +53917,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9351;
 									type="Land_Sun_chair_green_F";
@@ -53329,7 +53934,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9352;
 									type="Land_Sun_chair_green_F";
@@ -53346,7 +53951,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9354;
 									type="Land_Sun_chair_green_F";
@@ -53364,7 +53969,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9355;
 									type="Land_Sun_chair_green_F";
@@ -53381,7 +53986,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9358;
 									type="Land_Sun_chair_green_F";
@@ -53399,7 +54004,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9359;
 									type="Land_Sun_chair_green_F";
@@ -53417,7 +54022,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9360;
 									type="Land_Sun_chair_green_F";
@@ -53434,7 +54039,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9363;
 									type="Land_Sun_chair_green_F";
@@ -53452,7 +54057,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9364;
 									type="Land_Sun_chair_green_F";
@@ -53469,7 +54074,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9994;
 									type="FirePlace_burning_F";
@@ -53550,17 +54155,18 @@ class Mission
 											dataType="Object";
 											class PositionInfo
 											{
-												position[]={4518,16.136356,10424.5};
-												angles[]={0.0089968694,1.5644599,0.002990101};
+												position[]={4518,16.136276,10424.5};
+												angles[]={0.0089884456,1.5644608,0.0029845131};
 											};
 											side="Empty";
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=8171;
 											type="Land_Hlaska";
-											atlOffset=-0.094918251;
+											atlOffset=-0.094999313;
 										};
 										class Item1
 										{
@@ -53571,17 +54177,18 @@ class Mission
 												angles[]={0.0089884456,1.5491892,0.0029845131};
 											};
 											side="Empty";
+											flags=4;
 											class Attributes
 											{
 												disableSimulation=1;
 											};
 											id=8172;
 											type="B_HMG_01_high_F";
-											atlOffset=6.8110008;
+											atlOffset=5.7220459e-006;
 										};
 									};
 									id=6498;
-									atlOffset=3.3580427;
+									atlOffset=3.3580027;
 								};
 								class Item2
 								{
@@ -53719,11 +54326,11 @@ class Mission
 								};
 							};
 							id=6465;
-							atlOffset=0.73872852;
+							atlOffset=0.73871899;
 						};
 					};
 					id=82;
-					atlOffset=0.37912846;
+					atlOffset=0.37912369;
 				};
 				class Item2
 				{
@@ -53866,7 +54473,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6413;
 									type="Land_ChairWood_F";
@@ -53883,7 +54490,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6414;
 									type="Land_ChairWood_F";
@@ -53901,7 +54508,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6415;
 									type="Land_ChairWood_F";
@@ -53919,7 +54526,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6416;
 									type="Land_ChairWood_F";
@@ -53937,7 +54544,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6417;
 									type="Land_ChairWood_F";
@@ -53954,7 +54561,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6418;
 									type="Land_ChairWood_F";
@@ -53971,7 +54578,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6420;
 									type="Land_ChairWood_F";
@@ -53988,7 +54595,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6421;
 									type="Land_ChairWood_F";
@@ -54005,7 +54612,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6422;
 									type="Land_ChairWood_F";
@@ -54022,7 +54629,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6423;
 									type="Land_ChairWood_F";
@@ -54039,7 +54646,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6424;
 									type="Land_ChairWood_F";
@@ -54056,7 +54663,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6425;
 									type="Land_ChairWood_F";
@@ -54074,7 +54681,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6426;
 									type="Land_ChairWood_F";
@@ -54092,7 +54699,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6427;
 									type="Land_ChairWood_F";
@@ -54110,7 +54717,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6428;
 									type="Land_ChairWood_F";
@@ -54128,7 +54735,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6429;
 									type="Land_ChairWood_F";
@@ -54146,7 +54753,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6454;
 									type="Land_ChairWood_F";
@@ -54163,7 +54770,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6455;
 									type="Land_ChairWood_F";
@@ -54180,7 +54787,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6438;
 									type="FirePlace_burning_F";
@@ -54197,7 +54804,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6439;
 									type="FirePlace_burning_F";
@@ -54214,7 +54821,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6440;
 									type="FirePlace_burning_F";
@@ -54231,7 +54838,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6441;
 									type="FirePlace_burning_F";
@@ -54249,7 +54856,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6442;
 									type="FirePlace_burning_F";
@@ -54267,7 +54874,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6443;
 									type="FirePlace_burning_F";
@@ -54284,7 +54891,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6444;
 									type="FirePlace_burning_F";
@@ -54302,7 +54909,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6446;
 									type="FirePlace_burning_F";
@@ -54318,7 +54925,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6449;
 									type="FirePlace_burning_F";
@@ -54334,7 +54941,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6450;
 									type="FirePlace_burning_F";
@@ -54351,7 +54958,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6451;
 									type="FirePlace_burning_F";
@@ -54369,7 +54976,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6452;
 									type="FirePlace_burning_F";
@@ -54387,7 +54994,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6453;
 									type="FirePlace_burning_F";
@@ -54404,7 +55011,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8938;
 									type="Land_CampingChair_V1_folded_F";
@@ -54422,7 +55029,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8939;
 									type="Land_CampingChair_V1_folded_F";
@@ -54440,7 +55047,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8940;
 									type="Land_CampingChair_V1_F";
@@ -54458,7 +55065,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8941;
 									type="Land_CampingChair_V1_F";
@@ -54476,7 +55083,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8942;
 									type="Land_CampingChair_V1_F";
@@ -54494,7 +55101,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8943;
 									type="Land_CampingChair_V1_F";
@@ -54512,7 +55119,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8944;
 									type="Land_CampingChair_V1_folded_F";
@@ -54530,7 +55137,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8937;
 									type="Campfire_burning_F";
@@ -54548,7 +55155,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8947;
 									type="Land_FieldToilet_F";
@@ -54565,7 +55172,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8948;
 									type="Land_FieldToilet_F";
@@ -54582,7 +55189,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9275;
 									type="Land_Wreck_BMP2_F";
@@ -54599,7 +55206,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9281;
 									type="Land_Wreck_BMP2_F";
@@ -54617,7 +55224,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9276;
 									type="Campfire_burning_F";
@@ -54635,7 +55242,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9282;
 									type="Campfire_burning_F";
@@ -54652,7 +55259,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9277;
 									type="Land_CampingChair_V1_F";
@@ -54669,7 +55276,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9278;
 									type="Land_CampingChair_V1_F";
@@ -54687,7 +55294,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9283;
 									type="Land_CampingChair_V1_F";
@@ -54705,7 +55312,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9284;
 									type="Land_CampingChair_V1_F";
@@ -54722,7 +55329,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9279;
 									type="Land_CampingChair_V1_folded_F";
@@ -54739,7 +55346,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9285;
 									type="Land_CampingChair_V1_folded_F";
@@ -54756,7 +55363,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9280;
 									type="Land_Wreck_Ural_F";
@@ -54885,6 +55492,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=6394;
 											type="Land_Hlaska";
@@ -54902,6 +55510,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=6395;
 											type="Land_Hlaska";
@@ -54919,6 +55528,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=6396;
 											type="Land_Hlaska";
@@ -55414,7 +56024,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8007;
 									type="Land_Sun_chair_F";
@@ -55432,7 +56042,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8008;
 									type="Land_Sunshade_F";
@@ -55450,7 +56060,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8009;
 									type="FirePlace_burning_F";
@@ -55468,7 +56078,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8010;
 									type="Land_Sun_chair_F";
@@ -55486,7 +56096,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8011;
 									type="Land_Sun_chair_F";
@@ -55504,7 +56114,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8012;
 									type="Land_Sunshade_F";
@@ -55521,7 +56131,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8014;
 									type="Land_Sun_chair_F";
@@ -55539,7 +56149,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8015;
 									type="Land_Sun_chair_F";
@@ -55557,7 +56167,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8016;
 									type="Land_Sunshade_F";
@@ -55575,7 +56185,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8018;
 									type="Land_RowBoat_V1_F";
@@ -55593,7 +56203,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8019;
 									type="Land_RowBoat_V2_F";
@@ -55611,7 +56221,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8020;
 									type="Land_RowBoat_V3_F";
@@ -55629,7 +56239,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8006;
 									type="Land_Sun_chair_F";
@@ -55647,7 +56257,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8021;
 									type="FirePlace_burning_F";
@@ -55665,7 +56275,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8022;
 									type="FirePlace_burning_F";
@@ -55683,7 +56293,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9001;
 									type="Land_CampingChair_V1_F";
@@ -55701,7 +56311,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9002;
 									type="Land_CampingChair_V1_folded_F";
@@ -55719,7 +56329,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9003;
 									type="Campfire_burning_F";
@@ -55737,7 +56347,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9000;
 									type="Land_CampingChair_V1_F";
@@ -55755,7 +56365,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9111;
 									type="Land_CampingChair_V1_F";
@@ -55773,7 +56383,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9112;
 									type="Land_CampingChair_V1_F";
@@ -55791,7 +56401,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9113;
 									type="Land_CampingChair_V1_F";
@@ -55809,7 +56419,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9114;
 									type="Land_CampingChair_V1_F";
@@ -55827,7 +56437,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9115;
 									type="Land_CampingChair_V1_folded_F";
@@ -55844,7 +56454,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9116;
 									type="Campfire_burning_F";
@@ -55862,7 +56472,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9117;
 									type="Land_FieldToilet_F";
@@ -55880,7 +56490,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9118;
 									type="Land_FieldToilet_F";
@@ -55898,7 +56508,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9119;
 									type="Land_CampingChair_V1_folded_F";
@@ -55915,7 +56525,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9110;
 									type="Land_CampingChair_V1_folded_F";
@@ -55933,7 +56543,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9272;
 									type="Land_Wreck_HMMWV_F";
@@ -55950,7 +56560,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9268;
 									type="Land_Bench_01_F";
@@ -55968,7 +56578,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9269;
 									type="Land_ChairWood_F";
@@ -55985,7 +56595,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9270;
 									type="Land_ChairWood_F";
@@ -56002,7 +56612,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9274;
 									type="Land_ChairWood_F";
@@ -56019,7 +56629,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9271;
 									type="FirePlace_burning_F";
@@ -56036,7 +56646,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9273;
 									type="FirePlace_burning_F";
@@ -56117,17 +56727,18 @@ class Mission
 											dataType="Object";
 											class PositionInfo
 											{
-												position[]={2079,11.636355,6613.5};
-												angles[]={0.037718605,4.8218489,0.02083689};
+												position[]={2079,11.636776,6613.5};
+												angles[]={0.037716564,4.821856,0.020839231};
 											};
 											side="Empty";
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=7998;
 											type="Land_Hlaska";
-											atlOffset=0.18057919;
+											atlOffset=0.18099976;
 										};
 										class Item1
 										{
@@ -56138,18 +56749,17 @@ class Mission
 												angles[]={0.037716564,4.8676186,0.020856686};
 											};
 											side="Empty";
-											flags=4;
 											class Attributes
 											{
 												disableSimulation=1;
 											};
 											id=8001;
 											type="B_HMG_01_high_F";
-											atlOffset=8.392334e-005;
+											atlOffset=7.0899992;
 										};
 									};
 									id=6492;
-									atlOffset=3.635272;
+									atlOffset=3.6354818;
 								};
 								class Item2
 								{
@@ -56287,11 +56897,11 @@ class Mission
 								};
 							};
 							id=6463;
-							atlOffset=1.2027845;
+							atlOffset=1.202837;
 						};
 					};
 					id=85;
-					atlOffset=0.69914055;
+					atlOffset=0.69916725;
 				};
 				class Item4
 				{
@@ -56448,7 +57058,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8262;
 									type="Land_Sunshade_F";
@@ -56466,7 +57076,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8263;
 									type="FirePlace_burning_F";
@@ -56484,7 +57094,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8266;
 									type="Land_Sunshade_F";
@@ -56502,7 +57112,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8268;
 									type="Land_Sun_chair_F";
@@ -56520,7 +57130,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8270;
 									type="Land_Sunshade_F";
@@ -56538,7 +57148,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8272;
 									type="Land_RowBoat_V1_F";
@@ -56556,7 +57166,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8273;
 									type="Land_RowBoat_V2_F";
@@ -56574,7 +57184,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8274;
 									type="Land_RowBoat_V3_F";
@@ -56592,7 +57202,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8275;
 									type="Land_Sun_chair_F";
@@ -56610,7 +57220,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8261;
 									type="Land_Sun_chair_F";
@@ -56628,7 +57238,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8276;
 									type="FirePlace_burning_F";
@@ -56646,7 +57256,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8280;
 									type="FirePlace_burning_F";
@@ -56664,7 +57274,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8277;
 									type="Land_Sun_chair_F";
@@ -56682,7 +57292,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8278;
 									type="Land_Sun_chair_F";
@@ -56700,7 +57310,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8281;
 									type="Land_Sun_chair_F";
@@ -56718,7 +57328,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9013;
 									type="Land_CampingChair_V1_F";
@@ -56736,7 +57346,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9014;
 									type="Land_CampingChair_V1_folded_F";
@@ -56754,7 +57364,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9015;
 									type="Campfire_burning_F";
@@ -56772,7 +57382,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9012;
 									type="Land_CampingChair_V1_F";
@@ -56789,7 +57399,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9141;
 									type="Land_CampingChair_V1_F";
@@ -56807,7 +57417,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9142;
 									type="Land_CampingChair_V1_F";
@@ -56825,7 +57435,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9143;
 									type="Land_CampingChair_V1_F";
@@ -56842,7 +57452,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9144;
 									type="Land_CampingChair_V1_folded_F";
@@ -56860,7 +57470,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9145;
 									type="Campfire_burning_F";
@@ -56878,7 +57488,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9146;
 									type="Land_FieldToilet_F";
@@ -56896,7 +57506,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9147;
 									type="Land_FieldToilet_F";
@@ -56914,7 +57524,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9148;
 									type="Land_CampingChair_V1_folded_F";
@@ -56932,7 +57542,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9149;
 									type="Land_CampingChair_V1_folded_F";
@@ -56949,7 +57559,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9140;
 									type="Land_CampingChair_V1_F";
@@ -56967,7 +57577,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9371;
 									type="Campfire_burning_F";
@@ -56984,7 +57594,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9368;
 									type="Land_CampingChair_V1_F";
@@ -57001,7 +57611,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9369;
 									type="Land_CampingChair_V1_F";
@@ -57019,7 +57629,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9370;
 									type="Land_CampingChair_V1_folded_F";
@@ -57036,7 +57646,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9366;
 									type="Land_Wreck_T72_hull_F";
@@ -57052,7 +57662,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9367;
 									type="Land_Wreck_T72_turret_F";
@@ -57070,7 +57680,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9990;
 									type="Land_ChairWood_F";
@@ -57087,7 +57697,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9991;
 									type="FirePlace_burning_F";
@@ -57167,17 +57777,18 @@ class Mission
 											dataType="Object";
 											class PositionInfo
 											{
-												position[]={4320.5,10.636355,10924};
-												angles[]={0.0209908,5.607738,0.0090034921};
+												position[]={4320.5,10.636528,10924};
+												angles[]={0.02099631,5.6077428,0.0090058986};
 											};
 											side="Empty";
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=8255;
 											type="Land_Hlaska";
-											atlOffset=-0.030172348;
+											atlOffset=-0.03000021;
 										};
 										class Item1
 										{
@@ -57195,11 +57806,11 @@ class Mission
 											};
 											id=8256;
 											type="B_HMG_01_high_F";
-											atlOffset=0.00036048889;
+											atlOffset=0.00019168854;
 										};
 									};
 									id=6501;
-									atlOffset=3.4234118;
+									atlOffset=3.4234977;
 								};
 								class Item2
 								{
@@ -57337,11 +57948,11 @@ class Mission
 								};
 							};
 							id=6466;
-							atlOffset=0.41056061;
+							atlOffset=0.41058254;
 						};
 					};
 					id=87;
-					atlOffset=1.0086908;
+					atlOffset=1.0087023;
 				};
 				class Item5
 				{
@@ -57492,18 +58103,18 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
-										position[]={6347.5,13.349535,9657};
-										angles[]={6.2402177,1.440362,0.034183096};
+										position[]={6347.5,13.349496,9657};
+										angles[]={6.2402153,1.4403678,0.034191001};
 									};
 									side="Empty";
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8368;
 									type="Land_Wreck_BMP2_F";
-									atlOffset=-0.17695999;
+									atlOffset=-0.17699909;
 								};
 								class Item1
 								{
@@ -57517,7 +58128,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8367;
 									type="Land_Wreck_Ural_F";
@@ -57535,7 +58146,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9021;
 									type="Land_CampingChair_V1_F";
@@ -57553,7 +58164,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9022;
 									type="Land_CampingChair_V1_folded_F";
@@ -57571,7 +58182,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9023;
 									type="Campfire_burning_F";
@@ -57588,7 +58199,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9020;
 									type="Land_CampingChair_V1_F";
@@ -57606,7 +58217,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9161;
 									type="Land_CampingChair_V1_F";
@@ -57624,7 +58235,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9162;
 									type="Land_CampingChair_V1_F";
@@ -57642,7 +58253,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9163;
 									type="Land_CampingChair_V1_F";
@@ -57660,7 +58271,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9164;
 									type="Land_CampingChair_V1_folded_F";
@@ -57677,7 +58288,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9165;
 									type="Campfire_burning_F";
@@ -57695,7 +58306,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9166;
 									type="Land_FieldToilet_F";
@@ -57713,7 +58324,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9167;
 									type="Land_FieldToilet_F";
@@ -57731,7 +58342,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9168;
 									type="Land_CampingChair_V1_folded_F";
@@ -57749,7 +58360,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9169;
 									type="Land_CampingChair_V1_folded_F";
@@ -57767,7 +58378,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9160;
 									type="Land_CampingChair_V1_F";
@@ -57785,7 +58396,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9400;
 									type="Campfire_burning_F";
@@ -57802,7 +58413,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9402;
 									type="Land_ChairWood_F";
@@ -57820,7 +58431,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9403;
 									type="Land_ChairWood_F";
@@ -57838,7 +58449,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9404;
 									type="FirePlace_burning_F";
@@ -57855,7 +58466,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9405;
 									type="FirePlace_burning_F";
@@ -57872,7 +58483,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9398;
 									type="Land_CampingChair_V1_F";
@@ -57889,7 +58500,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9399;
 									type="Land_CampingChair_V1_F";
@@ -57906,7 +58517,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9401;
 									type="Land_CampingChair_V1_folded_F";
@@ -57986,16 +58597,17 @@ class Mission
 											dataType="Object";
 											class PositionInfo
 											{
-												position[]={6385.5,15.136355,9650.5};
-												angles[]={0,1.2016647,0};
+												position[]={6385.5,15.13595,9650.5};
+												angles[]={0,1.2016592,0};
 											};
 											side="Empty";
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=8425;
 											type="Land_Hlaska";
-											atlOffset=0.25540543;
+											atlOffset=0.25500011;
 										};
 										class Item1
 										{
@@ -58013,11 +58625,11 @@ class Mission
 											};
 											id=8431;
 											type="B_HMG_01_high_F";
-											atlOffset=0.0004863739;
+											atlOffset=0.00089073181;
 										};
 									};
 									id=6507;
-									atlOffset=3.7226839;
+									atlOffset=3.7224817;
 								};
 								class Item2
 								{
@@ -58155,11 +58767,11 @@ class Mission
 								};
 							};
 							id=6468;
-							atlOffset=0.6534729;
+							atlOffset=0.65342236;
 						};
 					};
 					id=88;
-					atlOffset=0.43117332;
+					atlOffset=0.43114758;
 				};
 				class Item6
 				{
@@ -58289,7 +58901,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7545;
 									type="Land_Wreck_BRDM2_F";
@@ -58307,7 +58919,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7547;
 									type="Campfire_burning_F";
@@ -58325,7 +58937,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7548;
 									type="Land_Wreck_Skodovka_F";
@@ -58343,7 +58955,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7551;
 									type="Land_CampingChair_V1_F";
@@ -58361,7 +58973,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7552;
 									type="Land_CampingChair_V1_F";
@@ -58379,7 +58991,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7553;
 									type="Land_CampingChair_V1_F";
@@ -58397,7 +59009,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7554;
 									type="Land_CampingChair_V1_F";
@@ -58415,7 +59027,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7560;
 									type="Land_CampingChair_V1_folded_F";
@@ -58432,7 +59044,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7561;
 									type="Land_CampingChair_V1_folded_F";
@@ -58449,7 +59061,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7564;
 									type="TargetP_Inf_Acc2_F";
@@ -58466,7 +59078,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7565;
 									type="TargetP_Inf_Acc2_F";
@@ -58483,7 +59095,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7566;
 									type="TargetP_Inf_Acc2_F";
@@ -58500,7 +59112,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7567;
 									type="TargetP_Inf2_Acc2_F";
@@ -58517,7 +59129,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7568;
 									type="TargetP_Inf2_Acc2_F";
@@ -58534,7 +59146,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7569;
 									type="TargetP_Inf2_Acc2_F";
@@ -58552,7 +59164,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7570;
 									type="Land_Wreck_UAZ_F";
@@ -58570,7 +59182,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7571;
 									type="Land_Wreck_Ural_F";
@@ -58588,7 +59200,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7572;
 									type="Land_Shooting_range";
@@ -58605,7 +59217,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7573;
 									type="Land_Shooting_range";
@@ -58622,7 +59234,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7574;
 									type="Land_Shooting_range";
@@ -58639,7 +59251,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7575;
 									type="Land_Shooting_range";
@@ -58656,7 +59268,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7576;
 									type="Land_Shooting_range";
@@ -58673,7 +59285,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7583;
 									type="Land_Wreck_Ural_F";
@@ -58691,7 +59303,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7584;
 									type="Land_Wreck_BMP2_F";
@@ -58708,7 +59320,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7585;
 									type="Land_Wreck_UAZ_F";
@@ -58726,7 +59338,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7544;
 									type="Land_Wreck_BMP2_F";
@@ -58744,7 +59356,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7587;
 									type="Land_Wreck_BMP2_F";
@@ -58762,7 +59374,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7588;
 									type="Land_Wreck_BRDM2_F";
@@ -58780,7 +59392,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7590;
 									type="Land_Sun_chair_F";
@@ -58798,7 +59410,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7591;
 									type="Land_Sun_chair_F";
@@ -58816,7 +59428,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7592;
 									type="Land_Sunshade_F";
@@ -58834,7 +59446,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7589;
 									type="FirePlace_burning_F";
@@ -58852,7 +59464,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7593;
 									type="Land_Sun_chair_F";
@@ -58870,7 +59482,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7594;
 									type="Land_Sun_chair_F";
@@ -58887,7 +59499,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7595;
 									type="Land_Sunshade_F";
@@ -58905,7 +59517,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7596;
 									type="FirePlace_burning_F";
@@ -58923,7 +59535,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7597;
 									type="Land_Sun_chair_F";
@@ -58941,7 +59553,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7598;
 									type="Land_Sun_chair_F";
@@ -58959,7 +59571,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7599;
 									type="Land_Sunshade_F";
@@ -58977,7 +59589,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7601;
 									type="FirePlace_burning_F";
@@ -58995,7 +59607,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7602;
 									type="Land_RowBoat_V1_F";
@@ -59013,7 +59625,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7604;
 									type="Land_RowBoat_V2_F";
@@ -59031,7 +59643,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7603;
 									type="Land_RowBoat_V3_F";
@@ -59049,7 +59661,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7606;
 									type="Land_Shooting_range";
@@ -59067,7 +59679,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8989;
 									type="Land_CampingChair_V1_F";
@@ -59085,7 +59697,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8990;
 									type="Land_CampingChair_V1_folded_F";
@@ -59103,7 +59715,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8991;
 									type="Campfire_burning_F";
@@ -59121,7 +59733,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8988;
 									type="Land_CampingChair_V1_F";
@@ -59138,7 +59750,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9081;
 									type="Land_CampingChair_V1_F";
@@ -59156,7 +59768,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9082;
 									type="Land_CampingChair_V1_F";
@@ -59174,7 +59786,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9083;
 									type="Land_CampingChair_V1_F";
@@ -59192,7 +59804,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9084;
 									type="Land_CampingChair_V1_F";
@@ -59210,7 +59822,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9085;
 									type="Land_CampingChair_V1_folded_F";
@@ -59227,7 +59839,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9086;
 									type="Campfire_burning_F";
@@ -59245,7 +59857,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9087;
 									type="Land_FieldToilet_F";
@@ -59262,7 +59874,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9088;
 									type="Land_FieldToilet_F";
@@ -59280,7 +59892,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9089;
 									type="Land_CampingChair_V1_folded_F";
@@ -59297,7 +59909,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9080;
 									type="Land_CampingChair_V1_folded_F";
@@ -59314,7 +59926,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9260;
 									type="Campfire_burning_F";
@@ -59332,7 +59944,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9257;
 									type="Land_CampingChair_V1_F";
@@ -59350,7 +59962,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9258;
 									type="Land_CampingChair_V1_F";
@@ -59368,7 +59980,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9259;
 									type="Land_CampingChair_V1_folded_F";
@@ -59489,16 +60101,17 @@ class Mission
 											dataType="Object";
 											class PositionInfo
 											{
-												position[]={7908,28.636356,1468.5};
-												angles[]={0,3.875253,0};
+												position[]={7908,28.636181,1468.5};
+												angles[]={0,3.8752592,0};
 											};
 											side="Empty";
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=7482;
 											type="Land_Hlaska";
-											atlOffset=0.92017365;
+											atlOffset=0.91999817;
 										};
 										class Item1
 										{
@@ -59519,7 +60132,7 @@ class Mission
 										};
 									};
 									id=6483;
-									atlOffset=4.4396305;
+									atlOffset=4.4395428;
 								};
 								class Item2
 								{
@@ -59739,11 +60352,11 @@ class Mission
 								};
 							};
 							id=6460;
-							atlOffset=0.55771637;
+							atlOffset=0.55769539;
 						};
 					};
 					id=89;
-					atlOffset=2.6148987;
+					atlOffset=2.6148891;
 				};
 				class Item7
 				{
@@ -59887,7 +60500,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7183;
 									type="Land_Wreck_BMP2_F";
@@ -59905,7 +60518,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7184;
 									type="Land_Wreck_BRDM2_F";
@@ -59923,7 +60536,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7162;
 									type="Campfire_burning_F";
@@ -59941,7 +60554,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7185;
 									type="Land_Wreck_Skodovka_F";
@@ -59959,7 +60572,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7173;
 									type="Land_CampingChair_V1_F";
@@ -59977,7 +60590,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7174;
 									type="Land_CampingChair_V1_F";
@@ -59995,7 +60608,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7175;
 									type="Land_CampingChair_V1_F";
@@ -60013,7 +60626,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7176;
 									type="Land_CampingChair_V1_F";
@@ -60031,7 +60644,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7165;
 									type="Land_CampingChair_V1_folded_F";
@@ -60049,7 +60662,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7166;
 									type="Land_CampingChair_V1_folded_F";
@@ -60067,7 +60680,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7152;
 									type="TargetP_Inf_Acc2_F";
@@ -60085,7 +60698,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7153;
 									type="TargetP_Inf_Acc2_F";
@@ -60103,7 +60716,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7193;
 									type="TargetP_Inf_Acc2_F";
@@ -60121,7 +60734,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7190;
 									type="TargetP_Inf2_Acc2_F";
@@ -60139,7 +60752,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7191;
 									type="TargetP_Inf2_Acc2_F";
@@ -60157,7 +60770,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7192;
 									type="TargetP_Inf2_Acc2_F";
@@ -60175,7 +60788,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7186;
 									type="Land_Wreck_UAZ_F";
@@ -60193,7 +60806,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7194;
 									type="Land_Wreck_Ural_F";
@@ -60211,7 +60824,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7154;
 									type="Land_Shooting_range";
@@ -60229,7 +60842,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7155;
 									type="Land_Shooting_range";
@@ -60247,7 +60860,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7156;
 									type="Land_Shooting_range";
@@ -60265,7 +60878,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7157;
 									type="Land_Shooting_range";
@@ -60283,7 +60896,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7158;
 									type="Land_Shooting_range";
@@ -60301,7 +60914,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7181;
 									type="Land_Wreck_HMMWV_F";
@@ -60319,7 +60932,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7198;
 									type="Land_Shooting_range";
@@ -60337,7 +60950,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7199;
 									type="Land_Wreck_Ural_F";
@@ -60355,7 +60968,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7200;
 									type="Land_Wreck_BMP2_F";
@@ -60373,7 +60986,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7201;
 									type="Land_Wreck_UAZ_F";
@@ -60391,7 +61004,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7202;
 									type="Land_Wreck_HMMWV_F";
@@ -60409,7 +61022,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7219;
 									type="FirePlace_burning_F";
@@ -60427,7 +61040,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7220;
 									type="FirePlace_burning_F";
@@ -60445,7 +61058,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7221;
 									type="FirePlace_burning_F";
@@ -60463,7 +61076,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7210;
 									type="Land_Sun_chair_F";
@@ -60481,7 +61094,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7211;
 									type="Land_Sun_chair_F";
@@ -60499,7 +61112,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7213;
 									type="Land_Sun_chair_F";
@@ -60517,7 +61130,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7214;
 									type="Land_Sun_chair_F";
@@ -60535,7 +61148,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7216;
 									type="Land_Sun_chair_F";
@@ -60552,7 +61165,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7217;
 									type="Land_Sun_chair_F";
@@ -60570,7 +61183,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7212;
 									type="Land_Sunshade_F";
@@ -60588,7 +61201,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7215;
 									type="Land_Sunshade_F";
@@ -60606,7 +61219,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7218;
 									type="Land_Sunshade_F";
@@ -60624,7 +61237,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7242;
 									type="Campfire_burning_F";
@@ -60642,7 +61255,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7239;
 									type="Land_CampingChair_V1_F";
@@ -60660,7 +61273,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7240;
 									type="Land_CampingChair_V1_F";
@@ -60678,7 +61291,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7241;
 									type="Land_CampingChair_V1_folded_F";
@@ -60696,7 +61309,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7243;
 									type="Land_RowBoat_V1_F";
@@ -60714,7 +61327,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7246;
 									type="Land_RowBoat_V1_F";
@@ -60732,7 +61345,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7244;
 									type="Land_RowBoat_V2_F";
@@ -60750,7 +61363,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7247;
 									type="Land_RowBoat_V2_F";
@@ -60768,7 +61381,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7245;
 									type="Land_RowBoat_V3_F";
@@ -60786,7 +61399,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9061;
 									type="Land_CampingChair_V1_F";
@@ -60804,7 +61417,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9062;
 									type="Land_CampingChair_V1_F";
@@ -60822,7 +61435,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9063;
 									type="Land_CampingChair_V1_F";
@@ -60840,7 +61453,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9064;
 									type="Land_CampingChair_V1_F";
@@ -60858,7 +61471,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9065;
 									type="Land_CampingChair_V1_folded_F";
@@ -60875,7 +61488,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9066;
 									type="Campfire_burning_F";
@@ -60893,7 +61506,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9067;
 									type="Land_FieldToilet_F";
@@ -60911,7 +61524,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9068;
 									type="Land_FieldToilet_F";
@@ -60929,7 +61542,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9069;
 									type="Land_CampingChair_V1_folded_F";
@@ -60946,7 +61559,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9060;
 									type="Land_CampingChair_V1_folded_F";
@@ -60963,7 +61576,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9291;
 									type="FirePlace_burning_F";
@@ -60981,7 +61594,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9292;
 									type="Land_CampingChair_V1_F";
@@ -60998,7 +61611,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9293;
 									type="Land_CampingChair_V1_F";
@@ -61016,7 +61629,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9294;
 									type="Land_CampingChair_V1_F";
@@ -61034,7 +61647,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9295;
 									type="Land_CampingChair_V1_F";
@@ -61052,7 +61665,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9296;
 									type="Land_CampingChair_V1_folded_F";
@@ -61069,7 +61682,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9297;
 									type="Land_CampingChair_V1_folded_F";
@@ -61191,17 +61804,18 @@ class Mission
 											dataType="Object";
 											class PositionInfo
 											{
-												position[]={6526,9.1363554,8732};
-												angles[]={0.069881961,3.9379184,6.2232609};
+												position[]={6526,9.1361446,8732};
+												angles[]={0.069882989,3.9379168,6.223268};
 											};
 											side="Empty";
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=7203;
 											type="Land_Hlaska";
-											atlOffset=0.18321037;
+											atlOffset=0.18300009;
 										};
 										class Item1
 										{
@@ -61212,17 +61826,18 @@ class Mission
 												angles[]={0.069882989,3.9404299,6.2231112};
 											};
 											side="Empty";
+											flags=4;
 											class Attributes
 											{
 												disableSimulation=1;
 											};
 											id=8979;
 											type="B_HMG_01_high_F";
-											atlOffset=7.105;
+											atlOffset=0.00012302399;
 										};
 									};
 									id=6477;
-									atlOffset=3.6440821;
+									atlOffset=3.6439772;
 								};
 								class Item2
 								{
@@ -61442,11 +62057,11 @@ class Mission
 								};
 							};
 							id=6458;
-							atlOffset=0.99323893;
+							atlOffset=0.99321222;
 						};
 					};
 					id=90;
-					atlOffset=1.6581583;
+					atlOffset=1.658145;
 				};
 				class Item8
 				{
@@ -61551,7 +62166,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9037;
 									type="Land_CampingChair_V1_F";
@@ -61569,7 +62184,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9038;
 									type="Land_CampingChair_V1_folded_F";
@@ -61587,7 +62202,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9039;
 									type="Campfire_burning_F";
@@ -61604,7 +62219,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9036;
 									type="Land_CampingChair_V1_F";
@@ -61621,7 +62236,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9181;
 									type="Land_CampingChair_V1_F";
@@ -61639,7 +62254,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9182;
 									type="Land_CampingChair_V1_F";
@@ -61657,7 +62272,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9183;
 									type="Land_CampingChair_V1_F";
@@ -61675,7 +62290,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9184;
 									type="Land_CampingChair_V1_folded_F";
@@ -61692,7 +62307,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9185;
 									type="Campfire_burning_F";
@@ -61710,7 +62325,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9186;
 									type="Land_FieldToilet_F";
@@ -61728,7 +62343,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9187;
 									type="Land_FieldToilet_F";
@@ -61745,7 +62360,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9188;
 									type="Land_CampingChair_V1_folded_F";
@@ -61762,7 +62377,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9189;
 									type="Land_CampingChair_V1_folded_F";
@@ -61779,7 +62394,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9180;
 									type="Land_CampingChair_V1_F";
@@ -61797,7 +62412,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9441;
 									type="Land_Wreck_HMMWV_F";
@@ -61814,7 +62429,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9432;
 									type="Campfire_burning_F";
@@ -61832,7 +62447,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9442;
 									type="Campfire_burning_F";
@@ -61850,7 +62465,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9416;
 									type="Land_ChairWood_F";
@@ -61868,7 +62483,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9419;
 									type="Land_ChairWood_F";
@@ -61886,7 +62501,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9420;
 									type="Land_ChairWood_F";
@@ -61904,7 +62519,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9421;
 									type="Land_ChairWood_F";
@@ -61922,7 +62537,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9422;
 									type="Land_ChairWood_F";
@@ -61940,7 +62555,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9424;
 									type="Land_ChairWood_F";
@@ -61958,7 +62573,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9425;
 									type="Land_ChairWood_F";
@@ -61976,7 +62591,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9426;
 									type="Land_ChairWood_F";
@@ -61993,7 +62608,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9429;
 									type="Land_ChairWood_F";
@@ -62010,7 +62625,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9430;
 									type="Land_ChairWood_F";
@@ -62027,7 +62642,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9439;
 									type="Land_ChairWood_F";
@@ -62044,7 +62659,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9417;
 									type="FirePlace_burning_F";
@@ -62061,7 +62676,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9418;
 									type="FirePlace_burning_F";
@@ -62079,7 +62694,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9423;
 									type="FirePlace_burning_F";
@@ -62096,7 +62711,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9427;
 									type="FirePlace_burning_F";
@@ -62113,7 +62728,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9428;
 									type="FirePlace_burning_F";
@@ -62130,7 +62745,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9431;
 									type="FirePlace_burning_F";
@@ -62147,7 +62762,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9440;
 									type="FirePlace_burning_F";
@@ -62164,7 +62779,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9433;
 									type="Land_CampingChair_V1_F";
@@ -62182,7 +62797,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9434;
 									type="Land_CampingChair_V1_F";
@@ -62200,7 +62815,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9435;
 									type="Land_CampingChair_V1_F";
@@ -62218,7 +62833,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9436;
 									type="Land_CampingChair_V1_F";
@@ -62235,7 +62850,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9443;
 									type="Land_CampingChair_V1_F";
@@ -62252,7 +62867,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9444;
 									type="Land_CampingChair_V1_F";
@@ -62269,7 +62884,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9437;
 									type="Land_CampingChair_V1_folded_F";
@@ -62286,7 +62901,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9438;
 									type="Land_CampingChair_V1_folded_F";
@@ -62303,7 +62918,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9445;
 									type="Land_CampingChair_V1_folded_F";
@@ -62381,16 +62996,17 @@ class Mission
 											dataType="Object";
 											class PositionInfo
 											{
-												position[]={5726.5,14.136355,3505.5};
-												angles[]={0,0.56419522,0};
+												position[]={5726.5,14.136808,3505.5};
+												angles[]={0,0.56419516,0};
 											};
 											side="Empty";
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=8535;
 											type="Land_Hlaska";
-											atlOffset=0.6945467;
+											atlOffset=0.69499969;
 										};
 										class Item1
 										{
@@ -62411,7 +63027,7 @@ class Mission
 										};
 									};
 									id=6513;
-									atlOffset=4.1497622;
+									atlOffset=4.1499891;
 								};
 								class Item2
 								{
@@ -62549,11 +63165,11 @@ class Mission
 								};
 							};
 							id=6470;
-							atlOffset=1.2860537;
+							atlOffset=1.2861109;
 						};
 					};
 					id=91;
-					atlOffset=0.73529434;
+					atlOffset=0.73532295;
 				};
 				class Item9
 				{
@@ -62711,7 +63327,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9017;
 									type="Land_CampingChair_V1_F";
@@ -62729,7 +63345,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9018;
 									type="Land_CampingChair_V1_folded_F";
@@ -62746,7 +63362,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9019;
 									type="Campfire_burning_F";
@@ -62764,7 +63380,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9016;
 									type="Land_CampingChair_V1_F";
@@ -62782,7 +63398,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9155;
 									type="Campfire_burning_F";
@@ -62800,7 +63416,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9156;
 									type="Land_FieldToilet_F";
@@ -62818,7 +63434,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9157;
 									type="Land_FieldToilet_F";
@@ -62836,7 +63452,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9151;
 									type="Land_CampingChair_V1_F";
@@ -62854,7 +63470,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9152;
 									type="Land_CampingChair_V1_F";
@@ -62872,7 +63488,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9153;
 									type="Land_CampingChair_V1_F";
@@ -62890,7 +63506,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9150;
 									type="Land_CampingChair_V1_F";
@@ -62908,7 +63524,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9154;
 									type="Land_CampingChair_V1_folded_F";
@@ -62925,7 +63541,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9158;
 									type="Land_CampingChair_V1_folded_F";
@@ -62942,7 +63558,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9159;
 									type="Land_CampingChair_V1_folded_F";
@@ -62959,7 +63575,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9383;
 									type="Campfire_burning_F";
@@ -62977,7 +63593,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9391;
 									type="Campfire_burning_F";
@@ -62995,7 +63611,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9373;
 									type="Land_ChairWood_F";
@@ -63013,7 +63629,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9374;
 									type="Land_ChairWood_F";
@@ -63031,7 +63647,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9375;
 									type="Land_ChairWood_F";
@@ -63048,7 +63664,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9378;
 									type="Land_ChairWood_F";
@@ -63065,7 +63681,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9372;
 									type="FirePlace_burning_F";
@@ -63082,7 +63698,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9376;
 									type="FirePlace_burning_F";
@@ -63099,7 +63715,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9377;
 									type="FirePlace_burning_F";
@@ -63116,7 +63732,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9385;
 									type="Land_CampingChair_V1_F";
@@ -63133,7 +63749,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9386;
 									type="Land_CampingChair_V1_F";
@@ -63151,7 +63767,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9389;
 									type="Land_CampingChair_V1_F";
@@ -63169,7 +63785,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9392;
 									type="Land_CampingChair_V1_F";
@@ -63187,7 +63803,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9393;
 									type="Land_CampingChair_V1_F";
@@ -63205,7 +63821,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9387;
 									type="Land_CampingChair_V1_folded_F";
@@ -63222,7 +63838,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9388;
 									type="Land_CampingChair_V1_folded_F";
@@ -63239,7 +63855,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9394;
 									type="Land_CampingChair_V1_folded_F";
@@ -63257,7 +63873,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9395;
 									type="Land_CampingChair_V1_folded_F";
@@ -63275,7 +63891,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9396;
 									type="Land_CampingChair_V1_folded_F";
@@ -63293,7 +63909,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9397;
 									type="Land_CampingChair_V1_folded_F";
@@ -63311,7 +63927,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9379;
 									type="Land_Wreck_UAZ_F";
@@ -63328,7 +63944,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9390;
 									type="Land_Wreck_Ural_F";
@@ -63408,16 +64024,17 @@ class Mission
 											dataType="Object";
 											class PositionInfo
 											{
-												position[]={10309.5,36.636356,341.5};
-												angles[]={0,2.2256827,0};
+												position[]={10309.5,36.636101,341.5};
+												angles[]={0,2.2256789,0};
 											};
 											side="Empty";
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=8360;
 											type="Land_Hlaska";
-											atlOffset=0.6312561;
+											atlOffset=0.63100052;
 										};
 										class Item1
 										{
@@ -63428,17 +64045,18 @@ class Mission
 												angles[]={0,2.2354698,0};
 											};
 											side="Empty";
+											flags=4;
 											class Attributes
 											{
 												disableSimulation=1;
 											};
 											id=8362;
 											type="B_HMG_01_high_F";
-											atlOffset=7.5660019;
+											atlOffset=9.9182129e-005;
 										};
 									};
 									id=6504;
-									atlOffset=4.0986328;
+									atlOffset=4.0985031;
 								};
 								class Item2
 								{
@@ -63576,11 +64194,11 @@ class Mission
 								};
 							};
 							id=6467;
-							atlOffset=1.9087486;
+							atlOffset=1.9087181;
 						};
 					};
 					id=92;
-					atlOffset=0.86672211;
+					atlOffset=0.86670685;
 				};
 				class Item10
 				{
@@ -63710,7 +64328,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7765;
 									type="TargetP_Inf_Acc2_F";
@@ -63728,7 +64346,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7766;
 									type="TargetP_Inf_Acc2_F";
@@ -63745,7 +64363,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7768;
 									type="Land_Shooting_range";
@@ -63762,7 +64380,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7769;
 									type="Land_Shooting_range";
@@ -63779,7 +64397,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7770;
 									type="Land_Shooting_range";
@@ -63796,7 +64414,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7775;
 									type="Campfire_burning_F";
@@ -63814,7 +64432,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7778;
 									type="Land_CampingChair_V1_folded_F";
@@ -63831,7 +64449,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7779;
 									type="Land_CampingChair_V1_folded_F";
@@ -63849,7 +64467,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7786;
 									type="Land_CampingChair_V1_F";
@@ -63867,7 +64485,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7787;
 									type="Land_CampingChair_V1_F";
@@ -63885,7 +64503,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7788;
 									type="Land_CampingChair_V1_F";
@@ -63903,7 +64521,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7789;
 									type="Land_CampingChair_V1_F";
@@ -63921,7 +64539,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7794;
 									type="Land_Wreck_HMMWV_F";
@@ -63939,7 +64557,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7795;
 									type="Land_Wreck_BMP2_F";
@@ -63957,7 +64575,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7797;
 									type="Land_Wreck_BRDM2_F";
@@ -63975,7 +64593,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7798;
 									type="Land_Wreck_Skodovka_F";
@@ -63993,7 +64611,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7799;
 									type="Land_Wreck_UAZ_F";
@@ -64011,7 +64629,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7800;
 									type="Land_Wreck_Ural_F";
@@ -64029,7 +64647,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7801;
 									type="Land_Wreck_T72_hull_F";
@@ -64046,7 +64664,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7802;
 									type="Land_Wreck_T72_hull_F";
@@ -64063,7 +64681,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7803;
 									type="Land_Wreck_T72_turret_F";
@@ -64080,7 +64698,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7804;
 									type="Land_Wreck_T72_turret_F";
@@ -64098,7 +64716,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7805;
 									type="TargetP_Inf2_Acc2_F";
@@ -64115,7 +64733,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7806;
 									type="TargetP_Inf2_Acc2_F";
@@ -64133,7 +64751,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7807;
 									type="TargetP_Inf2_Acc2_F";
@@ -64150,7 +64768,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7764;
 									type="TargetP_Inf_Acc2_F";
@@ -64168,7 +64786,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7808;
 									type="Land_Wreck_T72_hull_F";
@@ -64184,7 +64802,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7809;
 									type="Land_Wreck_T72_turret_F";
@@ -64202,7 +64820,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7818;
 									type="Land_Wreck_T72_hull_F";
@@ -64219,7 +64837,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7819;
 									type="Land_Wreck_T72_turret_F";
@@ -64237,7 +64855,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7811;
 									type="Land_Shooting_range";
@@ -64255,7 +64873,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7817;
 									type="Land_Shooting_range";
@@ -64272,7 +64890,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7820;
 									type="Land_Shooting_range";
@@ -64290,7 +64908,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7822;
 									type="Land_Sun_chair_F";
@@ -64307,7 +64925,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7823;
 									type="Land_Sunshade_F";
@@ -64325,7 +64943,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7824;
 									type="FirePlace_burning_F";
@@ -64343,7 +64961,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7825;
 									type="Land_Sun_chair_F";
@@ -64361,7 +64979,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7826;
 									type="Land_Sun_chair_F";
@@ -64379,7 +64997,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7827;
 									type="Land_Sunshade_F";
@@ -64397,7 +65015,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7828;
 									type="FirePlace_burning_F";
@@ -64415,7 +65033,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7829;
 									type="Land_Sun_chair_F";
@@ -64433,7 +65051,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7830;
 									type="Land_Sun_chair_F";
@@ -64451,7 +65069,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7831;
 									type="Land_Sunshade_F";
@@ -64469,7 +65087,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7832;
 									type="FirePlace_burning_F";
@@ -64487,7 +65105,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7833;
 									type="Land_RowBoat_V1_F";
@@ -64505,7 +65123,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7834;
 									type="Land_RowBoat_V2_F";
@@ -64523,7 +65141,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7835;
 									type="Land_RowBoat_V3_F";
@@ -64541,7 +65159,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7821;
 									type="Land_Sun_chair_F";
@@ -64559,7 +65177,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8993;
 									type="Land_CampingChair_V1_F";
@@ -64577,7 +65195,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8994;
 									type="Land_CampingChair_V1_folded_F";
@@ -64595,7 +65213,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8995;
 									type="Campfire_burning_F";
@@ -64613,7 +65231,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8992;
 									type="Land_CampingChair_V1_F";
@@ -64631,7 +65249,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9091;
 									type="Land_CampingChair_V1_F";
@@ -64649,7 +65267,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9092;
 									type="Land_CampingChair_V1_F";
@@ -64667,7 +65285,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9093;
 									type="Land_CampingChair_V1_F";
@@ -64685,7 +65303,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9094;
 									type="Land_CampingChair_V1_F";
@@ -64702,7 +65320,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9095;
 									type="Land_CampingChair_V1_folded_F";
@@ -64720,7 +65338,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9096;
 									type="Campfire_burning_F";
@@ -64738,7 +65356,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9097;
 									type="Land_FieldToilet_F";
@@ -64756,7 +65374,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9098;
 									type="Land_FieldToilet_F";
@@ -64774,7 +65392,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9099;
 									type="Land_CampingChair_V1_folded_F";
@@ -64792,7 +65410,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9090;
 									type="Land_CampingChair_V1_folded_F";
@@ -64914,16 +65532,17 @@ class Mission
 											dataType="Object";
 											class PositionInfo
 											{
-												position[]={11049,34.136356,1602.5};
-												angles[]={0,2.4237008,0};
+												position[]={11049,34.136723,1602.5};
+												angles[]={0,2.4237037,0};
 											};
 											side="Empty";
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=7705;
 											type="Land_Hlaska";
-											atlOffset=0.96163177;
+											atlOffset=0.96199989;
 										};
 										class Item1
 										{
@@ -64934,18 +65553,17 @@ class Mission
 												angles[]={0,2.3995135,0};
 											};
 											side="Empty";
-											flags=4;
 											class Attributes
 											{
 												disableSimulation=1;
 											};
 											id=7707;
 											type="B_HMG_01_high_F";
-											atlOffset=0.00025177002;
+											atlOffset=7.9969997;
 										};
 									};
 									id=6486;
-									atlOffset=4.4792519;
+									atlOffset=4.479435;
 								};
 								class Item2
 								{
@@ -65165,11 +65783,11 @@ class Mission
 								};
 							};
 							id=6461;
-							atlOffset=-0.34308434;
+							atlOffset=-0.34303856;
 						};
 					};
 					id=93;
-					atlOffset=0.071048737;
+					atlOffset=0.071071625;
 				};
 				class Item11
 				{
@@ -65425,7 +66043,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6882;
 									type="TargetP_Inf_Acc2_F";
@@ -65443,7 +66061,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6883;
 									type="TargetP_Inf_Acc2_F";
@@ -65461,7 +66079,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6884;
 									type="Land_Shooting_range";
@@ -65479,7 +66097,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6885;
 									type="Land_Shooting_range";
@@ -65497,7 +66115,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6886;
 									type="Land_Shooting_range";
@@ -65515,7 +66133,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6887;
 									type="Land_Shooting_range";
@@ -65533,7 +66151,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6888;
 									type="Land_Shooting_range";
@@ -65551,7 +66169,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6889;
 									type="Land_Shooting_range";
@@ -65569,7 +66187,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6892;
 									type="Campfire_burning_F";
@@ -65587,7 +66205,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6895;
 									type="Land_CampingChair_V1_folded_F";
@@ -65604,7 +66222,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6896;
 									type="Land_CampingChair_V1_folded_F";
@@ -65621,7 +66239,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6903;
 									type="Land_CampingChair_V1_F";
@@ -65639,7 +66257,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6904;
 									type="Land_CampingChair_V1_F";
@@ -65657,7 +66275,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6905;
 									type="Land_CampingChair_V1_F";
@@ -65675,7 +66293,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6906;
 									type="Land_CampingChair_V1_F";
@@ -65693,7 +66311,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6911;
 									type="Land_Wreck_HMMWV_F";
@@ -65711,7 +66329,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6912;
 									type="Land_Wreck_BMP2_F";
@@ -65729,7 +66347,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6913;
 									type="Land_Wreck_BMP2_F";
@@ -65747,7 +66365,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6914;
 									type="Land_Wreck_BRDM2_F";
@@ -65765,7 +66383,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6915;
 									type="Land_Wreck_Skodovka_F";
@@ -65783,7 +66401,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6916;
 									type="Land_Wreck_UAZ_F";
@@ -65801,7 +66419,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6917;
 									type="Land_Wreck_Ural_F";
@@ -65819,7 +66437,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6919;
 									type="Land_Wreck_T72_hull_F";
@@ -65836,7 +66454,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6921;
 									type="Land_Wreck_T72_turret_F";
@@ -65854,7 +66472,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6922;
 									type="TargetP_Inf2_Acc2_F";
@@ -65872,7 +66490,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6923;
 									type="TargetP_Inf2_Acc2_F";
@@ -65890,7 +66508,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6924;
 									type="TargetP_Inf2_Acc2_F";
@@ -65908,7 +66526,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6881;
 									type="TargetP_Inf_Acc2_F";
@@ -65926,7 +66544,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6925;
 									type="Campfire_burning_F";
@@ -65944,7 +66562,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6926;
 									type="Land_CampingChair_V1_folded_F";
@@ -65962,7 +66580,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6927;
 									type="Land_CampingChair_V1_folded_F";
@@ -65980,7 +66598,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6928;
 									type="Land_CampingChair_V1_F";
@@ -65998,7 +66616,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6929;
 									type="Land_CampingChair_V1_F";
@@ -66016,7 +66634,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6930;
 									type="Land_CampingChair_V1_F";
@@ -66034,7 +66652,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6931;
 									type="Land_CampingChair_V1_F";
@@ -66052,7 +66670,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6932;
 									type="Land_CampingChair_V1_folded_F";
@@ -66070,7 +66688,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=6933;
 									type="Land_Wreck_Ural_F";
@@ -66088,7 +66706,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7223;
 									type="Campfire_burning_F";
@@ -66106,7 +66724,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7224;
 									type="Campfire_burning_F";
@@ -66124,7 +66742,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7225;
 									type="Campfire_burning_F";
@@ -66142,7 +66760,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7226;
 									type="Campfire_burning_F";
@@ -66160,7 +66778,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7227;
 									type="Land_CampingChair_V1_F";
@@ -66178,7 +66796,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7228;
 									type="Land_CampingChair_V1_F";
@@ -66196,7 +66814,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7230;
 									type="Land_CampingChair_V1_F";
@@ -66214,7 +66832,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7231;
 									type="Land_CampingChair_V1_F";
@@ -66232,7 +66850,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7233;
 									type="Land_CampingChair_V1_F";
@@ -66250,7 +66868,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7234;
 									type="Land_CampingChair_V1_F";
@@ -66268,7 +66886,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7236;
 									type="Land_CampingChair_V1_F";
@@ -66286,7 +66904,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7237;
 									type="Land_CampingChair_V1_F";
@@ -66304,7 +66922,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7229;
 									type="Land_CampingChair_V1_folded_F";
@@ -66322,7 +66940,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7232;
 									type="Land_CampingChair_V1_folded_F";
@@ -66340,7 +66958,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7235;
 									type="Land_CampingChair_V1_folded_F";
@@ -66358,7 +66976,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=7238;
 									type="Land_CampingChair_V1_folded_F";
@@ -66376,7 +66994,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8960;
 									type="Land_CampingChair_V1_folded_F";
@@ -66393,7 +67011,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8961;
 									type="Land_CampingChair_V1_F";
@@ -66411,7 +67029,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8962;
 									type="Land_CampingChair_V1_F";
@@ -66429,7 +67047,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8963;
 									type="Land_CampingChair_V1_F";
@@ -66446,7 +67064,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8964;
 									type="Land_CampingChair_V1_F";
@@ -66463,7 +67081,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8965;
 									type="Land_CampingChair_V1_folded_F";
@@ -66480,7 +67098,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8966;
 									type="Campfire_burning_F";
@@ -66498,7 +67116,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8967;
 									type="Land_FieldToilet_F";
@@ -66516,7 +67134,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8968;
 									type="Land_FieldToilet_F";
@@ -66534,7 +67152,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8959;
 									type="Land_CampingChair_V1_folded_F";
@@ -66551,7 +67169,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9286;
 									type="Land_Wreck_BMP2_F";
@@ -66568,7 +67186,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9290;
 									type="Campfire_burning_F";
@@ -66585,7 +67203,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9287;
 									type="Land_CampingChair_V1_F";
@@ -66602,7 +67220,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9288;
 									type="Land_CampingChair_V1_F";
@@ -66620,7 +67238,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9289;
 									type="Land_CampingChair_V1_folded_F";
@@ -66748,6 +67366,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=6523;
 											type="Land_Hlaska";
@@ -66765,6 +67384,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=6524;
 											type="Land_Hlaska";
@@ -66782,6 +67402,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=6525;
 											type="Land_Hlaska";
@@ -66798,6 +67419,7 @@ class Mission
 											side="Empty";
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=6526;
 											type="Land_Hlaska";
@@ -67203,7 +67825,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9041;
 									type="Land_CampingChair_V1_F";
@@ -67221,7 +67843,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9042;
 									type="Land_CampingChair_V1_folded_F";
@@ -67239,7 +67861,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9043;
 									type="Campfire_burning_F";
@@ -67257,7 +67879,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9040;
 									type="Land_CampingChair_V1_F";
@@ -67275,7 +67897,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9191;
 									type="Land_CampingChair_V1_F";
@@ -67293,7 +67915,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9192;
 									type="Land_CampingChair_V1_F";
@@ -67311,7 +67933,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9193;
 									type="Land_CampingChair_V1_F";
@@ -67329,7 +67951,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9194;
 									type="Land_CampingChair_V1_folded_F";
@@ -67346,7 +67968,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9195;
 									type="Campfire_burning_F";
@@ -67364,7 +67986,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9196;
 									type="Land_FieldToilet_F";
@@ -67382,7 +68004,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9197;
 									type="Land_FieldToilet_F";
@@ -67400,7 +68022,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9198;
 									type="Land_CampingChair_V1_folded_F";
@@ -67417,7 +68039,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9199;
 									type="Land_CampingChair_V1_folded_F";
@@ -67434,7 +68056,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9190;
 									type="Land_CampingChair_V1_F";
@@ -67452,7 +68074,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9447;
 									type="Campfire_burning_F";
@@ -67470,7 +68092,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9448;
 									type="Land_CampingChair_V1_F";
@@ -67488,7 +68110,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9449;
 									type="Land_CampingChair_V1_F";
@@ -67506,7 +68128,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9450;
 									type="Land_CampingChair_V1_F";
@@ -67523,7 +68145,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9451;
 									type="Land_CampingChair_V1_folded_F";
@@ -67540,7 +68162,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9452;
 									type="Land_CampingChair_V1_folded_F";
@@ -67557,7 +68179,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9446;
 									type="Land_Wreck_UAZ_F";
@@ -67574,7 +68196,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9453;
 									type="Land_ChairWood_F";
@@ -67592,7 +68214,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9456;
 									type="Land_ChairWood_F";
@@ -67609,7 +68231,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9454;
 									type="FirePlace_burning_F";
@@ -67626,7 +68248,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9455;
 									type="FirePlace_burning_F";
@@ -67643,7 +68265,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9460;
 									type="Campfire_burning_F";
@@ -67660,7 +68282,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9457;
 									type="Land_CampingChair_V1_F";
@@ -67678,7 +68300,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9458;
 									type="Land_CampingChair_V1_F";
@@ -67695,7 +68317,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9459;
 									type="Land_CampingChair_V1_folded_F";
@@ -67776,16 +68398,17 @@ class Mission
 											dataType="Object";
 											class PositionInfo
 											{
-												position[]={2138.5,44.136356,4769};
-												angles[]={0,0.25579995,0};
+												position[]={2138.5,44.136414,4769};
+												angles[]={0,0.25579545,0};
 											};
 											side="Empty";
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=8583;
 											type="Land_Hlaska";
-											atlOffset=0.27194214;
+											atlOffset=0.27199936;
 										};
 										class Item1
 										{
@@ -67803,11 +68426,11 @@ class Mission
 											};
 											id=8584;
 											type="B_HMG_01_high_F";
-											atlOffset=0.00015640259;
+											atlOffset=9.9182129e-005;
 										};
 									};
 									id=6516;
-									atlOffset=3.6918945;
+									atlOffset=3.6919212;
 								};
 								class Item2
 								{
@@ -67945,11 +68568,11 @@ class Mission
 								};
 							};
 							id=6471;
-							atlOffset=0.87340927;
+							atlOffset=0.8734169;
 						};
 					};
 					id=96;
-					atlOffset=-0.32858276;
+					atlOffset=-0.32857895;
 				};
 				class Item13
 				{
@@ -68118,7 +68741,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9005;
 									type="Land_CampingChair_V1_F";
@@ -68135,7 +68758,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9006;
 									type="Land_CampingChair_V1_folded_F";
@@ -68153,7 +68776,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9007;
 									type="Campfire_burning_F";
@@ -68170,7 +68793,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9004;
 									type="Land_CampingChair_V1_F";
@@ -68187,7 +68810,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9121;
 									type="Land_CampingChair_V1_F";
@@ -68204,7 +68827,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9122;
 									type="Land_CampingChair_V1_F";
@@ -68221,7 +68844,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9123;
 									type="Land_CampingChair_V1_F";
@@ -68238,7 +68861,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9124;
 									type="Land_CampingChair_V1_F";
@@ -68255,7 +68878,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9125;
 									type="Land_CampingChair_V1_folded_F";
@@ -68272,7 +68895,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9126;
 									type="Campfire_burning_F";
@@ -68289,7 +68912,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9127;
 									type="Land_FieldToilet_F";
@@ -68306,7 +68929,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9128;
 									type="Land_FieldToilet_F";
@@ -68323,7 +68946,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9129;
 									type="Land_CampingChair_V1_folded_F";
@@ -68340,7 +68963,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9120;
 									type="Land_CampingChair_V1_folded_F";
@@ -68357,7 +68980,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9320;
 									type="Land_Bench_01_F";
@@ -68374,7 +68997,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9321;
 									type="Land_ChairWood_F";
@@ -68391,7 +69014,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9324;
 									type="Land_ChairWood_F";
@@ -68408,7 +69031,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9325;
 									type="Land_ChairWood_F";
@@ -68425,7 +69048,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9328;
 									type="Land_ChairWood_F";
@@ -68442,7 +69065,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9329;
 									type="Land_ChairWood_F";
@@ -68459,7 +69082,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9322;
 									type="FirePlace_burning_F";
@@ -68476,7 +69099,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9326;
 									type="FirePlace_burning_F";
@@ -68493,7 +69116,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9327;
 									type="FirePlace_burning_F";
@@ -68510,7 +69133,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9323;
 									type="Land_Wreck_UAZ_F";
@@ -68527,7 +69150,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9330;
 									type="Land_ChairWood_F";
@@ -68544,7 +69167,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9331;
 									type="Land_ChairWood_F";
@@ -68561,7 +69184,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9332;
 									type="FirePlace_burning_F";
@@ -68639,12 +69262,13 @@ class Mission
 											class PositionInfo
 											{
 												position[]={5305.5,22.546902,9956};
-												angles[]={0,3.8672364,0};
+												angles[]={0,3.8672309,0};
 											};
 											side="Empty";
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=8129;
 											type="Land_Hlaska";
@@ -68953,7 +69577,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8997;
 									type="Land_CampingChair_V1_F";
@@ -68971,7 +69595,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8998;
 									type="Land_CampingChair_V1_folded_F";
@@ -68989,7 +69613,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8999;
 									type="Campfire_burning_F";
@@ -69006,7 +69630,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=8996;
 									type="Land_CampingChair_V1_F";
@@ -69023,7 +69647,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9101;
 									type="Land_CampingChair_V1_F";
@@ -69041,7 +69665,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9102;
 									type="Land_CampingChair_V1_F";
@@ -69059,7 +69683,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9103;
 									type="Land_CampingChair_V1_F";
@@ -69077,7 +69701,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9104;
 									type="Land_CampingChair_V1_F";
@@ -69095,7 +69719,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9105;
 									type="Land_CampingChair_V1_folded_F";
@@ -69112,7 +69736,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9106;
 									type="Campfire_burning_F";
@@ -69130,7 +69754,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9107;
 									type="Land_FieldToilet_F";
@@ -69148,7 +69772,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9108;
 									type="Land_FieldToilet_F";
@@ -69166,7 +69790,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9109;
 									type="Land_CampingChair_V1_folded_F";
@@ -69183,7 +69807,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9100;
 									type="Land_CampingChair_V1_folded_F";
@@ -69200,7 +69824,7 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9261;
 									type="Land_Bench_01_F";
@@ -69217,7 +69841,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9267;
 									type="Campfire_burning_F";
@@ -69234,7 +69858,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9263;
 									type="Land_ChairWood_F";
@@ -69251,7 +69875,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9262;
 									type="FirePlace_burning_F";
@@ -69268,7 +69892,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9264;
 									type="Land_CampingChair_V1_F";
@@ -69285,7 +69909,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9266;
 									type="Land_CampingChair_V1_F";
@@ -69303,7 +69927,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9265;
 									type="Land_CampingChair_V1_folded_F";
@@ -69321,7 +69945,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9305;
 									type="Land_Wreck_Skodovka_F";
@@ -69338,7 +69962,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9306;
 									type="Land_ChairWood_F";
@@ -69355,7 +69979,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9319;
 									type="Land_ChairWood_F";
@@ -69372,7 +69996,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9308;
 									type="FirePlace_burning_F";
@@ -69411,7 +70035,7 @@ class Mission
 											};
 											id=7927;
 											type="B_Slingload_01_Cargo_F";
-											atlOffset=0.0029983521;
+											atlOffset=0.0030021667;
 											class CustomAttributes
 											{
 												class Attribute0
@@ -69438,7 +70062,7 @@ class Mission
 										};
 									};
 									id=6488;
-									atlOffset=0.0029983521;
+									atlOffset=0.0030021667;
 								};
 								class Item1
 								{
@@ -69452,17 +70076,18 @@ class Mission
 											dataType="Object";
 											class PositionInfo
 											{
-												position[]={5360.5,66.636353,6240};
-												angles[]={0,5.2405787,0};
+												position[]={5360.5,66.63665,6240};
+												angles[]={0,5.2405782,0};
 											};
 											side="Empty";
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=7924;
 											type="Land_Hlaska";
-											atlOffset=-0.065299988;
+											atlOffset=-0.064998627;
 										};
 										class Item1
 										{
@@ -69480,11 +70105,11 @@ class Mission
 											};
 											id=7926;
 											type="B_HMG_01_high_F";
-											atlOffset=0.00045776367;
+											atlOffset=0.00016021729;
 										};
 									};
 									id=6489;
-									atlOffset=3.3878517;
+									atlOffset=3.3879967;
 								};
 								class Item2
 								{
@@ -69622,11 +70247,11 @@ class Mission
 								};
 							};
 							id=6462;
-							atlOffset=0.88993835;
+							atlOffset=0.8899765;
 						};
 					};
 					id=98;
-					atlOffset=-0.1037674;
+					atlOffset=-0.10374832;
 				};
 				class Item15
 				{
@@ -69730,7 +70355,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9025;
 									type="Land_CampingChair_V1_F";
@@ -69748,7 +70373,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9026;
 									type="Land_CampingChair_V1_folded_F";
@@ -69766,7 +70391,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9027;
 									type="Campfire_burning_F";
@@ -69783,7 +70408,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9024;
 									type="Land_CampingChair_V1_F";
@@ -69801,7 +70426,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9029;
 									type="Land_CampingChair_V1_F";
@@ -69819,7 +70444,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9030;
 									type="Land_CampingChair_V1_folded_F";
@@ -69837,7 +70462,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9031;
 									type="Campfire_burning_F";
@@ -69854,7 +70479,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9028;
 									type="Land_CampingChair_V1_F";
@@ -69872,7 +70497,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9033;
 									type="Land_CampingChair_V1_F";
@@ -69890,7 +70515,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9034;
 									type="Land_CampingChair_V1_folded_F";
@@ -69908,7 +70533,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9035;
 									type="Campfire_burning_F";
@@ -69926,7 +70551,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9032;
 									type="Land_CampingChair_V1_F";
@@ -69944,7 +70569,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9171;
 									type="Land_CampingChair_V1_F";
@@ -69962,7 +70587,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9172;
 									type="Land_CampingChair_V1_F";
@@ -69980,7 +70605,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9173;
 									type="Land_CampingChair_V1_F";
@@ -69998,7 +70623,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9174;
 									type="Land_CampingChair_V1_folded_F";
@@ -70015,7 +70640,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9175;
 									type="Campfire_burning_F";
@@ -70033,7 +70658,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9176;
 									type="Land_FieldToilet_F";
@@ -70051,7 +70676,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9177;
 									type="Land_FieldToilet_F";
@@ -70069,7 +70694,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9178;
 									type="Land_CampingChair_V1_folded_F";
@@ -70086,7 +70711,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9179;
 									type="Land_CampingChair_V1_folded_F";
@@ -70103,7 +70728,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9170;
 									type="Land_CampingChair_V1_F";
@@ -70121,7 +70746,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9408;
 									type="Land_ChairWood_F";
@@ -70138,7 +70763,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9407;
 									type="FirePlace_burning_F";
@@ -70156,7 +70781,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9409;
 									type="Land_Wreck_BRDM2_F";
@@ -70173,7 +70798,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9412;
 									type="Campfire_burning_F";
@@ -70191,7 +70816,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9410;
 									type="Land_CampingChair_V1_F";
@@ -70208,7 +70833,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9411;
 									type="Land_CampingChair_V1_F";
@@ -70225,7 +70850,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9414;
 									type="Land_CampingChair_V1_F";
@@ -70242,7 +70867,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9413;
 									type="Land_CampingChair_V1_folded_F";
@@ -70260,7 +70885,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9415;
 									type="Land_CampingChair_V1_folded_F";
@@ -70339,17 +70964,18 @@ class Mission
 											dataType="Object";
 											class PositionInfo
 											{
-												position[]={4492.5,20.636356,11239.5};
-												angles[]={0.0073971152,3.8628941,6.2812634};
+												position[]={4492.5,20.636799,11239.5};
+												angles[]={0.007400196,3.8629024,6.2812657};
 											};
 											side="Empty";
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=8477;
 											type="Land_Hlaska";
-											atlOffset=0.099555969;
+											atlOffset=0.10000038;
 										};
 										class Item1
 										{
@@ -70367,11 +70993,11 @@ class Mission
 											};
 											id=8479;
 											type="B_HMG_01_high_F";
-											atlOffset=0.00050163269;
+											atlOffset=5.9127808e-005;
 										};
 									};
 									id=6510;
-									atlOffset=3.5527821;
+									atlOffset=3.5530033;
 								};
 								class Item2
 								{
@@ -70509,15 +71135,15 @@ class Mission
 								};
 							};
 							id=6469;
-							atlOffset=0.9181366;
+							atlOffset=0.91819382;
 						};
 					};
 					id=195;
-					atlOffset=0.84389877;
+					atlOffset=0.84392929;
 				};
 			};
 			id=56;
-			atlOffset=9.6151333;
+			atlOffset=9.6151543;
 		};
 		class Item3
 		{
@@ -70851,7 +71477,7 @@ class Mission
 									colorName="ColorCIV";
 									a=9.3129997;
 									b=18.57;
-									angle=228.04044;
+									angle=228.04042;
 									id=168;
 									atlOffset=0.014520645;
 								};
@@ -70935,7 +71561,7 @@ class Mission
 									colorName="ColorCIV";
 									a=6.4770002;
 									b=20.827;
-									angle=226.65944;
+									angle=226.65942;
 									id=174;
 									atlOffset=-0.00022125244;
 								};
@@ -71164,6 +71790,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1722;
 											type="Land_Hlaska";
@@ -71180,6 +71807,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1723;
 											type="Land_Hlaska";
@@ -72154,7 +72782,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9201;
 									type="Land_CampingChair_V1_F";
@@ -72172,7 +72800,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9202;
 									type="Land_CampingChair_V1_F";
@@ -72190,7 +72818,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9203;
 									type="Land_CampingChair_V1_F";
@@ -72208,7 +72836,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9204;
 									type="Land_CampingChair_V1_folded_F";
@@ -72225,7 +72853,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9205;
 									type="Campfire_burning_F";
@@ -72243,7 +72871,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9206;
 									type="Land_FieldToilet_F";
@@ -72261,7 +72889,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9207;
 									type="Land_FieldToilet_F";
@@ -72279,7 +72907,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9208;
 									type="Land_CampingChair_V1_folded_F";
@@ -72297,7 +72925,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9209;
 									type="Land_CampingChair_V1_folded_F";
@@ -72314,7 +72942,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9200;
 									type="Land_CampingChair_V1_F";
@@ -72332,7 +72960,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9210;
 									type="Land_CampingChair_V1_F";
@@ -72350,7 +72978,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9211;
 									type="Land_CampingChair_V1_F";
@@ -72368,7 +72996,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9212;
 									type="Land_CampingChair_V1_F";
@@ -72386,7 +73014,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9213;
 									type="Land_CampingChair_V1_folded_F";
@@ -72404,7 +73032,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9214;
 									type="Campfire_burning_F";
@@ -72422,7 +73050,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9215;
 									type="Land_FieldToilet_F";
@@ -72440,7 +73068,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9216;
 									type="Land_FieldToilet_F";
@@ -72458,7 +73086,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9217;
 									type="Land_CampingChair_V1_folded_F";
@@ -72475,7 +73103,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9218;
 									type="Land_CampingChair_V1_folded_F";
@@ -72492,30 +73120,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9219;
 									type="Land_CampingChair_V1_F";
 									atlOffset=-4.9591064e-005;
 								};
 								class Item20
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={4983.9985,29.621401,10569.501};
-										angles[]={0.0053711003,0.66653365,0.0056205466};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-										disableSimulation=1;
-									};
-									id=9472;
-									type="Land_Campfire_F";
-								};
-								class Item21
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72527,13 +73138,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9470;
 									type="Campfire_burning_F";
 									atlOffset=6.1035156e-005;
 								};
-								class Item22
+								class Item21
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72545,12 +73156,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9490;
 									type="Campfire_burning_F";
 								};
-								class Item23
+								class Item22
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72562,13 +73173,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9496;
 									type="Campfire_burning_F";
 									atlOffset=-7.8201294e-005;
 								};
-								class Item24
+								class Item23
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72580,13 +73191,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9523;
 									type="Campfire_burning_F";
 									atlOffset=0.00032615662;
 								};
-								class Item25
+								class Item24
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72598,13 +73209,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9531;
 									type="Campfire_burning_F";
 									atlOffset=-0.00012207031;
 								};
-								class Item26
+								class Item25
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72616,12 +73227,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9543;
 									type="Campfire_burning_F";
 								};
-								class Item27
+								class Item26
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72633,13 +73244,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9544;
 									type="Campfire_burning_F";
 									atlOffset=-3.0517578e-005;
 								};
-								class Item28
+								class Item27
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72651,13 +73262,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9554;
 									type="Campfire_burning_F";
 									atlOffset=-3.8146973e-006;
 								};
-								class Item29
+								class Item28
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72669,12 +73280,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9463;
 									type="Land_ChairWood_F";
 								};
-								class Item30
+								class Item29
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72686,12 +73297,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9464;
 									type="Land_ChairWood_F";
 								};
-								class Item31
+								class Item30
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72703,13 +73314,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9465;
 									type="Land_ChairWood_F";
 									atlOffset=-8.392334e-005;
 								};
-								class Item32
+								class Item31
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72721,12 +73332,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9478;
 									type="Land_ChairWood_F";
 								};
-								class Item33
+								class Item32
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72738,13 +73349,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9479;
 									type="Land_ChairWood_F";
 									atlOffset=0.0012664795;
 								};
-								class Item34
+								class Item33
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72756,12 +73367,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9482;
 									type="Land_ChairWood_F";
 								};
-								class Item35
+								class Item34
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72773,12 +73384,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9483;
 									type="Land_ChairWood_F";
 								};
-								class Item36
+								class Item35
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72790,12 +73401,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9499;
 									type="Land_ChairWood_F";
 								};
-								class Item37
+								class Item36
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72807,12 +73418,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9500;
 									type="Land_ChairWood_F";
 								};
-								class Item38
+								class Item37
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72824,13 +73435,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9502;
 									type="Land_ChairWood_F";
 									atlOffset=1.9073486e-006;
 								};
-								class Item39
+								class Item38
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72842,13 +73453,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9503;
 									type="Land_ChairWood_F";
 									atlOffset=1.9073486e-006;
 								};
-								class Item40
+								class Item39
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72860,13 +73471,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9504;
 									type="Land_ChairWood_F";
 									atlOffset=1.9073486e-006;
 								};
-								class Item41
+								class Item40
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72878,12 +73489,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9505;
 									type="Land_ChairWood_F";
 								};
-								class Item42
+								class Item41
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72895,12 +73506,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9506;
 									type="Land_ChairWood_F";
 								};
-								class Item43
+								class Item42
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72912,12 +73523,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9507;
 									type="Land_ChairWood_F";
 								};
-								class Item44
+								class Item43
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72929,13 +73540,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9508;
 									type="Land_ChairWood_F";
 									atlOffset=-1.9073486e-006;
 								};
-								class Item45
+								class Item44
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72947,12 +73558,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9509;
 									type="Land_ChairWood_F";
 								};
-								class Item46
+								class Item45
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72964,12 +73575,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9527;
 									type="Land_ChairWood_F";
 								};
-								class Item47
+								class Item46
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72981,13 +73592,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9528;
 									type="Land_ChairWood_F";
 									atlOffset=-1.9073486e-006;
 								};
-								class Item48
+								class Item47
 								{
 									dataType="Object";
 									class PositionInfo
@@ -72999,12 +73610,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9517;
 									type="Land_FieldToilet_F";
 								};
-								class Item49
+								class Item48
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73016,13 +73627,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9518;
 									type="Land_FieldToilet_F";
 									atlOffset=-1.9073486e-006;
 								};
-								class Item50
+								class Item49
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73034,13 +73645,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9519;
 									type="Land_FieldToilet_F";
 									atlOffset=1.9073486e-006;
 								};
-								class Item51
+								class Item50
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73052,12 +73663,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9520;
 									type="Land_FieldToilet_F";
 								};
-								class Item52
+								class Item51
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73069,13 +73680,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9521;
 									type="Land_FieldToilet_F";
 									atlOffset=-1.9073486e-006;
 								};
-								class Item53
+								class Item52
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73087,13 +73698,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9522;
 									type="Land_FieldToilet_F";
 									atlOffset=1.9073486e-006;
 								};
-								class Item54
+								class Item53
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73105,13 +73716,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9461;
 									type="FirePlace_burning_F";
 									atlOffset=-1.7166138e-005;
 								};
-								class Item55
+								class Item54
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73123,13 +73734,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9462;
 									type="FirePlace_burning_F";
 									atlOffset=0.00023841858;
 								};
-								class Item56
+								class Item55
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73141,12 +73752,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9480;
 									type="FirePlace_burning_F";
 								};
-								class Item57
+								class Item56
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73158,12 +73769,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9481;
 									type="FirePlace_burning_F";
 								};
-								class Item58
+								class Item57
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73175,12 +73786,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9510;
 									type="FirePlace_burning_F";
 								};
-								class Item59
+								class Item58
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73192,12 +73803,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9511;
 									type="FirePlace_burning_F";
 								};
-								class Item60
+								class Item59
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73209,12 +73820,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9512;
 									type="FirePlace_burning_F";
 								};
-								class Item61
+								class Item60
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73226,12 +73837,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9513;
 									type="FirePlace_burning_F";
 								};
-								class Item62
+								class Item61
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73243,12 +73854,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9514;
 									type="FirePlace_burning_F";
 								};
-								class Item63
+								class Item62
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73260,12 +73871,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9515;
 									type="FirePlace_burning_F";
 								};
-								class Item64
+								class Item63
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73277,12 +73888,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9516;
 									type="FirePlace_burning_F";
 								};
-								class Item65
+								class Item64
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73294,12 +73905,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9529;
 									type="FirePlace_burning_F";
 								};
-								class Item66
+								class Item65
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73311,12 +73922,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9530;
 									type="FirePlace_burning_F";
 								};
-								class Item67
+								class Item66
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73328,12 +73939,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9466;
 									type="Land_CampingChair_V1_F";
 								};
-								class Item68
+								class Item67
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73345,12 +73956,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9467;
 									type="Land_CampingChair_V1_F";
 								};
-								class Item69
+								class Item68
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73362,12 +73973,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9468;
 									type="Land_CampingChair_V1_F";
 								};
-								class Item70
+								class Item69
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73379,13 +73990,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9473;
 									type="Land_CampingChair_V1_F";
 									atlOffset=-1.9073486e-006;
 								};
-								class Item71
+								class Item70
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73397,13 +74008,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9474;
 									type="Land_CampingChair_V1_F";
 									atlOffset=1.9073486e-006;
 								};
-								class Item72
+								class Item71
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73415,12 +74026,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9475;
 									type="Land_CampingChair_V1_F";
 								};
-								class Item73
+								class Item72
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73432,13 +74043,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9484;
 									type="Land_CampingChair_V1_F";
 									atlOffset=-9.5367432e-006;
 								};
-								class Item74
+								class Item73
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73450,13 +74061,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9485;
 									type="Land_CampingChair_V1_F";
 									atlOffset=-5.7220459e-006;
 								};
-								class Item75
+								class Item74
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73468,13 +74079,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9486;
 									type="Land_CampingChair_V1_F";
 									atlOffset=3.8146973e-006;
 								};
-								class Item76
+								class Item75
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73486,13 +74097,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9489;
 									type="Land_CampingChair_V1_F";
 									atlOffset=-3.8146973e-006;
 								};
-								class Item77
+								class Item76
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73504,13 +74115,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9493;
 									type="Land_CampingChair_V1_F";
 									atlOffset=-5.9127808e-005;
 								};
-								class Item78
+								class Item77
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73522,13 +74133,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9494;
 									type="Land_CampingChair_V1_F";
 									atlOffset=-5.3405762e-005;
 								};
-								class Item79
+								class Item78
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73540,13 +74151,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9495;
 									type="Land_CampingChair_V1_F";
 									atlOffset=-2.4795532e-005;
 								};
-								class Item80
+								class Item79
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73558,12 +74169,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9524;
 									type="Land_CampingChair_V1_F";
 								};
-								class Item81
+								class Item80
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73575,12 +74186,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9525;
 									type="Land_CampingChair_V1_F";
 								};
-								class Item82
+								class Item81
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73592,13 +74203,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9532;
 									type="Land_CampingChair_V1_F";
 									atlOffset=-8.392334e-005;
 								};
-								class Item83
+								class Item82
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73610,12 +74221,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9533;
 									type="Land_CampingChair_V1_F";
 								};
-								class Item84
+								class Item83
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73627,13 +74238,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9534;
 									type="Land_CampingChair_V1_F";
 									atlOffset=4.3869019e-005;
 								};
-								class Item85
+								class Item84
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73645,13 +74256,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9538;
 									type="Land_CampingChair_V1_F";
 									atlOffset=-0.00037002563;
 								};
-								class Item86
+								class Item85
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73663,12 +74274,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9539;
 									type="Land_CampingChair_V1_F";
 								};
-								class Item87
+								class Item86
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73680,12 +74291,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9540;
 									type="Land_CampingChair_V1_F";
 								};
-								class Item88
+								class Item87
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73697,13 +74308,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9545;
 									type="Land_CampingChair_V1_F";
 									atlOffset=-3.6239624e-005;
 								};
-								class Item89
+								class Item88
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73715,12 +74326,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9546;
 									type="Land_CampingChair_V1_F";
 								};
-								class Item90
+								class Item89
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73732,12 +74343,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9547;
 									type="Land_CampingChair_V1_F";
 								};
-								class Item91
+								class Item90
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73749,12 +74360,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9551;
 									type="Land_CampingChair_V1_F";
 								};
-								class Item92
+								class Item91
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73766,13 +74377,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9552;
 									type="Land_CampingChair_V1_F";
 									atlOffset=-1.9073486e-006;
 								};
-								class Item93
+								class Item92
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73784,13 +74395,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9476;
 									type="Land_CampingChair_V1_folded_F";
 									atlOffset=7.6293945e-006;
 								};
-								class Item94
+								class Item93
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73802,13 +74413,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9477;
 									type="Land_CampingChair_V1_folded_F";
 									atlOffset=5.7220459e-006;
 								};
-								class Item95
+								class Item94
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73820,13 +74431,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9491;
 									type="Land_CampingChair_V1_folded_F";
 									atlOffset=5.7220459e-006;
 								};
-								class Item96
+								class Item95
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73838,13 +74449,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9492;
 									type="Land_CampingChair_V1_folded_F";
 									atlOffset=5.531311e-005;
 								};
-								class Item97
+								class Item96
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73856,13 +74467,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9497;
 									type="Land_CampingChair_V1_folded_F";
 									atlOffset=2.0980835e-005;
 								};
-								class Item98
+								class Item97
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73874,13 +74485,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9498;
 									type="Land_CampingChair_V1_folded_F";
 									atlOffset=0.00011825562;
 								};
-								class Item99
+								class Item98
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73892,12 +74503,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9526;
 									type="Land_CampingChair_V1_folded_F";
 								};
-								class Item100
+								class Item99
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73909,13 +74520,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9535;
 									type="Land_CampingChair_V1_folded_F";
 									atlOffset=0.00012588501;
 								};
-								class Item101
+								class Item100
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73927,13 +74538,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9536;
 									type="Land_CampingChair_V1_folded_F";
 									atlOffset=0.00026702881;
 								};
-								class Item102
+								class Item101
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73945,13 +74556,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9537;
 									type="Land_CampingChair_V1_folded_F";
 									atlOffset=0.00026321411;
 								};
-								class Item103
+								class Item102
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73963,12 +74574,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9541;
 									type="Land_CampingChair_V1_folded_F";
 								};
-								class Item104
+								class Item103
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73980,12 +74591,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9542;
 									type="Land_CampingChair_V1_folded_F";
 								};
-								class Item105
+								class Item104
 								{
 									dataType="Object";
 									class PositionInfo
@@ -73997,13 +74608,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9548;
 									type="Land_CampingChair_V1_folded_F";
 									atlOffset=0.00018310547;
 								};
-								class Item106
+								class Item105
 								{
 									dataType="Object";
 									class PositionInfo
@@ -74015,12 +74626,12 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9549;
 									type="Land_CampingChair_V1_folded_F";
 								};
-								class Item107
+								class Item106
 								{
 									dataType="Object";
 									class PositionInfo
@@ -74032,13 +74643,13 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9550;
 									type="Land_CampingChair_V1_folded_F";
 									atlOffset=0.00015449524;
 								};
-								class Item108
+								class Item107
 								{
 									dataType="Object";
 									class PositionInfo
@@ -74050,19 +74661,36 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9553;
 									type="Land_CampingChair_V1_folded_F";
 									atlOffset=1.7166138e-005;
 								};
+								class Item108
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={4983.5024,29.618628,10569.498};
+										angles[]={0.0053756139,0,0.0056199599};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										dynamicSimulation=1;
+									};
+									id=9998;
+									type="Campfire_burning_F";
+								};
 							};
 							id=1814;
-							atlOffset=-1.1581917;
+							atlOffset=-0.50376129;
 						};
 					};
 					id=78;
-					atlOffset=-0.037748337;
+					atlOffset=-0.22756577;
 				};
 				class Item1
 				{
@@ -74756,6 +75384,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1647;
 											type="Land_Hlaska";
@@ -74773,6 +75402,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1648;
 											type="Land_Hlaska";
@@ -74789,6 +75419,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1650;
 											type="Land_Hlaska";
@@ -74805,6 +75436,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1651;
 											type="Land_Hlaska";
@@ -74822,6 +75454,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1655;
 											type="Land_Hlaska";
@@ -75360,7 +75993,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9231;
 									type="Land_CampingChair_V1_F";
@@ -75378,7 +76011,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9232;
 									type="Land_CampingChair_V1_F";
@@ -75396,7 +76029,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9233;
 									type="Land_CampingChair_V1_folded_F";
@@ -75413,7 +76046,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9234;
 									type="Campfire_burning_F";
@@ -75431,7 +76064,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9235;
 									type="Land_FieldToilet_F";
@@ -75449,7 +76082,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9236;
 									type="Land_FieldToilet_F";
@@ -75467,7 +76100,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9237;
 									type="Land_CampingChair_V1_folded_F";
@@ -75484,7 +76117,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9238;
 									type="Land_CampingChair_V1_folded_F";
@@ -75501,7 +76134,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9239;
 									type="Land_CampingChair_V1_F";
@@ -75519,7 +76152,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9230;
 									type="Land_CampingChair_V1_F";
@@ -75537,7 +76170,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9597;
 									type="FirePlace_burning_F";
@@ -75555,7 +76188,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9606;
 									type="Land_RowBoat_V1_F";
@@ -75573,7 +76206,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9608;
 									type="Land_RowBoat_V2_F";
@@ -75591,7 +76224,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9610;
 									type="Land_RowBoat_V3_F";
@@ -75609,7 +76242,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9598;
 									type="Land_Sun_chair_F";
@@ -75627,7 +76260,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9599;
 									type="Land_Sun_chair_F";
@@ -75644,7 +76277,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9600;
 									type="Land_Sun_chair_F";
@@ -75662,7 +76295,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9601;
 									type="Land_Sun_chair_F";
@@ -75679,7 +76312,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9602;
 									type="Land_Sun_chair_F";
@@ -75696,7 +76329,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9603;
 									type="Land_Sunshade_F";
@@ -75713,7 +76346,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9604;
 									type="Land_Sunshade_F";
@@ -75730,7 +76363,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9605;
 									type="Land_Sunshade_F";
@@ -75748,7 +76381,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9596;
 									type="FirePlace_burning_F";
@@ -75766,7 +76399,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9611;
 									type="FirePlace_burning_F";
@@ -75784,7 +76417,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9612;
 									type="Land_Sun_chair_F";
@@ -75801,7 +76434,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9660;
 									type="Campfire_burning_F";
@@ -75819,7 +76452,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9661;
 									type="Campfire_burning_F";
@@ -75836,7 +76469,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9668;
 									type="Campfire_burning_F";
@@ -75854,7 +76487,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9617;
 									type="Land_ChairWood_F";
@@ -75872,7 +76505,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9618;
 									type="Land_ChairWood_F";
@@ -75890,7 +76523,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9620;
 									type="Land_ChairWood_F";
@@ -75908,7 +76541,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9621;
 									type="Land_ChairWood_F";
@@ -75926,7 +76559,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9624;
 									type="Land_ChairWood_F";
@@ -75943,7 +76576,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9625;
 									type="Land_ChairWood_F";
@@ -75960,7 +76593,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9626;
 									type="Land_ChairWood_F";
@@ -75978,7 +76611,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9627;
 									type="Land_ChairWood_F";
@@ -75996,7 +76629,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9633;
 									type="Land_ChairWood_F";
@@ -76014,7 +76647,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9634;
 									type="Land_ChairWood_F";
@@ -76032,7 +76665,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9635;
 									type="Land_ChairWood_F";
@@ -76050,7 +76683,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9636;
 									type="Land_ChairWood_F";
@@ -76067,7 +76700,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9637;
 									type="Land_ChairWood_F";
@@ -76084,7 +76717,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9638;
 									type="Land_ChairWood_F";
@@ -76102,7 +76735,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9639;
 									type="Land_ChairWood_F";
@@ -76119,7 +76752,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9640;
 									type="Land_ChairWood_F";
@@ -76137,7 +76770,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9641;
 									type="Land_ChairWood_F";
@@ -76154,7 +76787,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9642;
 									type="Land_ChairWood_F";
@@ -76171,7 +76804,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9643;
 									type="Land_ChairWood_F";
@@ -76189,7 +76822,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9644;
 									type="Land_ChairWood_F";
@@ -76207,7 +76840,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9645;
 									type="Land_ChairWood_F";
@@ -76224,7 +76857,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9664;
 									type="Land_ChairWood_F";
@@ -76242,7 +76875,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9665;
 									type="Land_ChairWood_F";
@@ -76260,7 +76893,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9667;
 									type="Land_ChairWood_F";
@@ -76278,7 +76911,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9629;
 									type="Land_FieldToilet_F";
@@ -76296,7 +76929,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9630;
 									type="Land_FieldToilet_F";
@@ -76314,7 +76947,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9631;
 									type="Land_FieldToilet_F";
@@ -76332,7 +76965,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9632;
 									type="Land_FieldToilet_F";
@@ -76350,7 +76983,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9613;
 									type="FirePlace_burning_F";
@@ -76368,7 +77001,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9619;
 									type="FirePlace_burning_F";
@@ -76385,7 +77018,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9622;
 									type="FirePlace_burning_F";
@@ -76402,7 +77035,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9623;
 									type="FirePlace_burning_F";
@@ -76419,7 +77052,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9628;
 									type="FirePlace_burning_F";
@@ -76436,7 +77069,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9646;
 									type="FirePlace_burning_F";
@@ -76453,7 +77086,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9647;
 									type="FirePlace_burning_F";
@@ -76470,7 +77103,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9648;
 									type="FirePlace_burning_F";
@@ -76487,7 +77120,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9650;
 									type="FirePlace_burning_F";
@@ -76504,7 +77137,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9651;
 									type="FirePlace_burning_F";
@@ -76521,7 +77154,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9652;
 									type="FirePlace_burning_F";
@@ -76538,7 +77171,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9653;
 									type="FirePlace_burning_F";
@@ -76555,7 +77188,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9654;
 									type="FirePlace_burning_F";
@@ -76571,7 +77204,7 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9666;
 									type="FirePlace_burning_F";
@@ -76589,7 +77222,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9614;
 									type="Land_CampingChair_V1_F";
@@ -76607,7 +77240,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9615;
 									type="Land_CampingChair_V1_F";
@@ -76624,7 +77257,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9655;
 									type="Land_CampingChair_V1_F";
@@ -76642,7 +77275,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9656;
 									type="Land_CampingChair_V1_F";
@@ -76660,7 +77293,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9657;
 									type="Land_CampingChair_V1_F";
@@ -76678,7 +77311,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9658;
 									type="Land_CampingChair_V1_F";
@@ -76696,7 +77329,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9669;
 									type="Land_CampingChair_V1_F";
@@ -76714,7 +77347,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9670;
 									type="Land_CampingChair_V1_F";
@@ -76732,7 +77365,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9671;
 									type="Land_CampingChair_V1_F";
@@ -76750,7 +77383,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9616;
 									type="Land_CampingChair_V1_folded_F";
@@ -76768,7 +77401,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9662;
 									type="Land_CampingChair_V1_folded_F";
@@ -76786,7 +77419,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9663;
 									type="Land_CampingChair_V1_folded_F";
@@ -76803,7 +77436,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9672;
 									type="Land_CampingChair_V1_folded_F";
@@ -76820,7 +77453,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9673;
 									type="Land_CampingChair_V1_folded_F";
@@ -76838,7 +77471,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9674;
 									type="Land_CampingChair_V1_folded_F";
@@ -76856,7 +77489,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9678;
 									type="Campfire_burning_F";
@@ -76874,7 +77507,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9675;
 									type="Land_CampingChair_V1_F";
@@ -76892,7 +77525,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9676;
 									type="Land_CampingChair_V1_F";
@@ -76910,7 +77543,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9677;
 									type="Land_CampingChair_V1_folded_F";
@@ -76927,7 +77560,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9680;
 									type="Land_CampingChair_V1_folded_F";
@@ -77655,6 +78288,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1545;
 											type="Land_Hlaska";
@@ -77671,6 +78305,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1546;
 											type="Land_Hlaska";
@@ -77687,6 +78322,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1547;
 											type="Land_Hlaska";
@@ -77704,6 +78340,7 @@ class Mission
 											flags=4;
 											class Attributes
 											{
+												dynamicSimulation=1;
 											};
 											id=1549;
 											type="Land_Hlaska";
@@ -78142,7 +78779,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9045;
 									type="Land_CampingChair_V1_F";
@@ -78160,7 +78797,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9046;
 									type="Land_CampingChair_V1_folded_F";
@@ -78178,7 +78815,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9047;
 									type="Campfire_burning_F";
@@ -78196,7 +78833,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9044;
 									type="Land_CampingChair_V1_F";
@@ -78214,7 +78851,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9048;
 									type="Land_CampingChair_V1_F";
@@ -78232,7 +78869,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9049;
 									type="Land_CampingChair_V1_folded_F";
@@ -78250,7 +78887,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9050;
 									type="Campfire_burning_F";
@@ -78268,7 +78905,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9051;
 									type="Land_CampingChair_V1_F";
@@ -78286,7 +78923,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9052;
 									type="Land_CampingChair_V1_F";
@@ -78304,7 +78941,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9053;
 									type="Land_CampingChair_V1_folded_F";
@@ -78322,7 +78959,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9054;
 									type="Campfire_burning_F";
@@ -78339,7 +78976,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9055;
 									type="Land_CampingChair_V1_F";
@@ -78357,7 +78994,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9056;
 									type="Land_CampingChair_V1_F";
@@ -78375,7 +79012,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9057;
 									type="Land_CampingChair_V1_folded_F";
@@ -78393,7 +79030,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9058;
 									type="Campfire_burning_F";
@@ -78410,7 +79047,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9059;
 									type="Land_CampingChair_V1_F";
@@ -78427,7 +79064,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9221;
 									type="Land_CampingChair_V1_F";
@@ -78445,7 +79082,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9222;
 									type="Land_CampingChair_V1_F";
@@ -78463,7 +79100,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9223;
 									type="Land_CampingChair_V1_folded_F";
@@ -78480,7 +79117,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9224;
 									type="Campfire_burning_F";
@@ -78497,7 +79134,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9225;
 									type="Land_FieldToilet_F";
@@ -78515,7 +79152,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9226;
 									type="Land_FieldToilet_F";
@@ -78532,7 +79169,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9227;
 									type="Land_CampingChair_V1_folded_F";
@@ -78549,7 +79186,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9228;
 									type="Land_CampingChair_V1_folded_F";
@@ -78566,7 +79203,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9229;
 									type="Land_CampingChair_V1_F";
@@ -78583,7 +79220,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9220;
 									type="Land_CampingChair_V1_F";
@@ -78600,7 +79237,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9556;
 									type="Land_ChairWood_F";
@@ -78618,7 +79255,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9557;
 									type="Land_ChairWood_F";
@@ -78636,7 +79273,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9558;
 									type="Land_ChairWood_F";
@@ -78654,7 +79291,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9561;
 									type="Land_ChairWood_F";
@@ -78672,7 +79309,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9563;
 									type="Land_ChairWood_F";
@@ -78689,7 +79326,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9564;
 									type="Land_ChairWood_F";
@@ -78707,7 +79344,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9568;
 									type="Land_ChairWood_F";
@@ -78725,7 +79362,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9569;
 									type="Land_ChairWood_F";
@@ -78742,7 +79379,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9572;
 									type="Land_ChairWood_F";
@@ -78760,7 +79397,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9573;
 									type="Land_ChairWood_F";
@@ -78778,7 +79415,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9574;
 									type="Land_ChairWood_F";
@@ -78796,7 +79433,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9577;
 									type="Land_ChairWood_F";
@@ -78813,7 +79450,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9578;
 									type="Land_ChairWood_F";
@@ -78830,7 +79467,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9579;
 									type="Land_ChairWood_F";
@@ -78847,7 +79484,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9555;
 									type="FirePlace_burning_F";
@@ -78864,7 +79501,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9559;
 									type="FirePlace_burning_F";
@@ -78881,7 +79518,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9560;
 									type="FirePlace_burning_F";
@@ -78898,7 +79535,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9566;
 									type="FirePlace_burning_F";
@@ -78916,7 +79553,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9567;
 									type="FirePlace_burning_F";
@@ -78934,7 +79571,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9570;
 									type="FirePlace_burning_F";
@@ -78951,7 +79588,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9571;
 									type="FirePlace_burning_F";
@@ -78968,7 +79605,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9575;
 									type="FirePlace_burning_F";
@@ -78985,7 +79622,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9576;
 									type="FirePlace_burning_F";
@@ -79003,7 +79640,7 @@ class Mission
 									flags=4;
 									class Attributes
 									{
-										disableSimulation=1;
+										dynamicSimulation=1;
 									};
 									id=9580;
 									type="FirePlace_burning_F";
@@ -79019,7 +79656,7 @@ class Mission
 				};
 			};
 			id=57;
-			atlOffset=-61.685719;
+			atlOffset=-60.296352;
 		};
 		class Item4
 		{


### PR DESCRIPTION
- Enabled dynamic simulation for all map props: (burning) campfires and fireplaces, chairs, benches, watchtowers, etc.
*EXCLUDING ammo, helipad, static weapon, and vehicle map markups (as well as civilian boat spawns).

Shouldn't impact performance as "Entity Simulation is enabled only if the player or enemy unit is nearby."

With this enabled, campfires should now light up again (and toilet boxes and chairs can be knocked over if you're within vicinity of them).

No longer is Everon a pitch black (at night)  and static landscape. Enjoy and OFP never dies!