### PR TITLE
Disable incorrect icon-colouring code in Arsenal Container

### DIFF
--- a/src/JeroenArsenal/JNA/fn_arsenal_container.sqf
+++ b/src/JeroenArsenal/JNA/fn_arsenal_container.sqf
@@ -306,6 +306,7 @@ switch _mode do {
 	///////////////////////////////////////////////////////////////////////////////////////////
 	case "ColorTabs":{
 		params["_display"];
+/*		
 		{
 			_ctrlTab = _display displayctrl (IDC_RSCDISPLAYARSENAL_TAB + _forEachIndex);
 
@@ -321,6 +322,7 @@ switch _mode do {
 			_ctrlTab ctrlSetForegroundColor _color;
 		} forEach jnva_loadout;
 	};
+*/
 
 	///////////////////////////////////////////////////////////////////////////////////////////
 	case "TabSelect": {

--- a/src/JeroenArsenal/JNA/fn_arsenal_container.sqf
+++ b/src/JeroenArsenal/JNA/fn_arsenal_container.sqf
@@ -321,8 +321,9 @@ switch _mode do {
 			_ctrlTab ctrlSetBackgroundColor _color;
 			_ctrlTab ctrlSetForegroundColor _color;
 		} forEach jnva_loadout;
-	};
 */
+	};
+
 
 	///////////////////////////////////////////////////////////////////////////////////////////
 	case "TabSelect": {


### PR DESCRIPTION
Arma 3's Art of War Update (2.02) broke the Arsenal to Containers UI, All Buttons will have their Fore and Background in the same color,
Which makes using it a bit harder than it should be.

This PR is basically a copy of [John's PR](https://github.com/official-antistasi-community/A3-Antistasi/pull/1820) for Antistasi, which seems to work pretty well as noone complained about the Vehicle Arsenal's Ui being broken anymore.

Pretty easy to reproduce as you just need to use Arsenal to External Inventory and you should see the problem.

Ofcourse if somebody wants to fix Icon Coloring he is free todo so, but this would be a Quick fix by disabling the coloring.

Before:
![107410_20210801115337_1](https://user-images.githubusercontent.com/57111907/127766790-4304cb0d-11a1-40ed-a9e7-8a884f122ff3.png)


After: 
![107410_20210801114919_1](https://user-images.githubusercontent.com/57111907/127766721-cad345d7-1ecf-45e1-8bed-92b6e70637d4.png)